### PR TITLE
Update Scientific Python link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 See the [Scientific Python Developer Guide][spc-dev-intro] for a detailed
 description of best practices for developing scientific packages.
 
-[spc-dev-intro]: https://scientific-python-cookie.readthedocs.io/guide/intro
+[spc-dev-intro]: https://scientific-python-cookie.readthedocs.io/en/stable/
 
 # Quick development
 


### PR DESCRIPTION
The link to the Scientific Python guide changed
Addresses and resolves the conversation from PR https://github.com/Ciela-Institute/caustics/pull/106 and Conversation https://github.com/Ciela-Institute/caustics/pull/106#discussion_r1414430843