### PR TITLE
Adding gaussian quadrature integrator

### DIFF
--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -61,7 +61,6 @@ class Lens_Source(Simulator):
         psf=None,
         pixels_y: Optional[int] = None,
         upsample_factor: int = 1,
-        quad_level: int = 1,
         psf_pad=True,
         psf_mode="fft",
         z_s=None,
@@ -79,7 +78,6 @@ class Lens_Source(Simulator):
             self.psf = torch.as_tensor(psf)
             self.psf /= psf.sum()  # ensure normalized
         self.add_param("z_s", z_s)
-        self.quad_level = quad_level
 
         # Image grid
         if pixels_y is None:
@@ -143,6 +141,7 @@ class Lens_Source(Simulator):
         lens_light=True,
         lens_source=True,
         psf_convolve=True,
+        quad_level=None,
     ):
         """
         params: Packed object
@@ -157,9 +156,9 @@ class Lens_Source(Simulator):
         if source_light:
             if lens_source:
                 # Source is lensed by the lens mass distribution
-                if self.quad_level > 1:
+                if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        *self.grid, self.quad_level
+                        *self.grid, quad_level
                     )
                     bx, by = self.lens.raytrace(
                         finegrid_x, finegrid_y, z_s, params
@@ -173,9 +172,9 @@ class Lens_Source(Simulator):
                     mu = self.source.brightness(bx, by, params)
             else:
                 # Source is imaged without lensing
-                if self.quad_level > 1:
+                if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        *self.grid, self.quad_level
+                        *self.grid, quad_level
                     )
                     mu_fine = self.source.brightness(
                         finegrid_x, finegrid_y, params
@@ -191,9 +190,9 @@ class Lens_Source(Simulator):
 
         # Sample the lens light
         if lens_light and self.lens_light is not None:
-            if self.quad_level > 1:
+            if quad_level is not None and quad_level > 1:
                 finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                    *self.grid, self.quad_level
+                    *self.grid, quad_level
                 )
                 mu_fine = self.lens_light.brightness(
                     finegrid_x, finegrid_y, params

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -159,7 +159,7 @@ class Lens_Source(Simulator):
                 # Source is lensed by the lens mass distribution
                 if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        self.pixelscale, *self.grid, quad_level
+                        self.pixelscale/self.upsample_factor, *self.grid, quad_level
                     )
                     bx, by = self.lens.raytrace(
                         finegrid_x, finegrid_y, z_s, params
@@ -175,7 +175,7 @@ class Lens_Source(Simulator):
                 # Source is imaged without lensing
                 if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        self.pixelscale, *self.grid, quad_level
+                        self.pixelscale/self.upsample_factor, *self.grid, quad_level
                     )
                     mu_fine = self.source.brightness(
                         finegrid_x, finegrid_y, params
@@ -193,7 +193,7 @@ class Lens_Source(Simulator):
         if lens_light and self.lens_light is not None:
             if quad_level is not None and quad_level > 1:
                 finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                    self.pixelscale, *self.grid, quad_level
+                    self.pixelscale/self.upsample_factor, *self.grid, quad_level
                 )
                 mu_fine = self.lens_light.brightness(
                     finegrid_x, finegrid_y, params

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -166,16 +166,18 @@ class Lens_Source(Simulator):
         if self.lens_light is None:
             lens_light = False
         if self.psf is None:
-            psf_convolve = False      
+            psf_convolve = False 
+
+        if quad_level is not None and quad_level > 1:   
+            finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
+                self.pixelscale/self.upsample_factor, *self.grid, quad_level
+            )              
 
         # Sample the source light
         if source_light:
             if lens_source:
                 # Source is lensed by the lens mass distribution
                 if quad_level is not None and quad_level > 1:
-                    finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
-                        self.pixelscale/self.upsample_factor, *self.grid, quad_level
-                    )
                     bx, by = self.lens.raytrace(
                         finegrid_x, finegrid_y, z_s, params
                     )
@@ -189,9 +191,6 @@ class Lens_Source(Simulator):
             else:
                 # Source is imaged without lensing
                 if quad_level is not None and quad_level > 1:
-                    finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
-                        self.pixelscale/self.upsample_factor, *self.grid, quad_level
-                    )
                     mu_fine = self.source.brightness(
                         finegrid_x, finegrid_y, params
                     )
@@ -207,9 +206,6 @@ class Lens_Source(Simulator):
         # Sample the lens light
         if lens_light and self.lens_light is not None:
             if quad_level is not None and quad_level > 1:
-                finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
-                    self.pixelscale/self.upsample_factor, *self.grid, quad_level
-                )
                 mu_fine = self.lens_light.brightness(
                     finegrid_x, finegrid_y, params
                 )

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -78,6 +78,7 @@ class Lens_Source(Simulator):
             self.psf = torch.as_tensor(psf)
             self.psf /= psf.sum()  # ensure normalized
         self.add_param("z_s", z_s)
+        self.pixelscale = pixelscale
 
         # Image grid
         if pixels_y is None:
@@ -158,7 +159,7 @@ class Lens_Source(Simulator):
                 # Source is lensed by the lens mass distribution
                 if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        *self.grid, quad_level
+                        self.pixelscale, *self.grid, quad_level
                     )
                     bx, by = self.lens.raytrace(
                         finegrid_x, finegrid_y, z_s, params
@@ -174,7 +175,7 @@ class Lens_Source(Simulator):
                 # Source is imaged without lensing
                 if quad_level is not None and quad_level > 1:
                     finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                        *self.grid, quad_level
+                        self.pixelscale, *self.grid, quad_level
                     )
                     mu_fine = self.source.brightness(
                         finegrid_x, finegrid_y, params
@@ -192,7 +193,7 @@ class Lens_Source(Simulator):
         if lens_light and self.lens_light is not None:
             if quad_level is not None and quad_level > 1:
                 finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
-                    *self.grid, quad_level
+                    self.pixelscale, *self.grid, quad_level
                 )
                 mu_fine = self.lens_light.brightness(
                     finegrid_x, finegrid_y, params

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -160,6 +160,14 @@ class Lens_Source(Simulator):
         """
         (z_s,) = self.unpack(params)
 
+        # Automatically turn off light for missing objects
+        if self.source is None:
+            source_light = False
+        if self.lens_light is None:
+            lens_light = False
+        if self.psf is None:
+            psf_convolve = False      
+
         # Sample the source light
         if source_light:
             if lens_source:

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -106,7 +106,7 @@ class Lens_Source(Simulator):
             self.gridding[1] + self.psf_pad[1] * 2,
         )
         self.grid = get_meshgrid(
-            pixelscale, self.n_pix[0]*self.upsample_factor, self.n_pix[1]*self.upsample_factor
+            pixelscale/self.upsample_factor, self.n_pix[0]*self.upsample_factor, self.n_pix[1]*self.upsample_factor
         )
 
         if self.psf is not None:

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -44,10 +44,17 @@ class Lens_Source(Simulator):
       lens_light (optional): caustics light object which defines the lensing object's light
       psf (optional): An image to convolve with the scene. Note that if ``upsample_factor > 1`` the psf must also be at the higher resolution.
       pixels_y (optional): number of pixels on the y-axis for the sampling grid. If left as ``None`` then this will simply be equal to ``gridx``
-      upsample_factor (default 1): Amount of upsampling to model the image. For example ``upsample_factor = 2`` indicates that the image will be sampled at double the resolution then summed back to the original resolution (given by pixelscale and gridx/y).
+      upsample_factor (default 1): Amount of upsampling to model the image. For example ``upsample_factor = 2`` indicates that the image will be sampled at double the resolution then summed back to the original resolution (given by pixelscale and gridx/y). Note that if you are using a PSF then the PSF must also be at the higher resolution.
       psf_pad (default True): If convolving the PSF it is important to sample the model in a larger FOV equal to half the PSF size in order to account for light that scatters from outside the requested FOV inwards. Internally this padding will be added before sampling, then cropped off before returning the final image to the user.
       z_s (optional): redshift of the source
       name (default "sim"): a name for this simulator in the parameter DAG.
+
+    Notes:
+    -----
+    - The simulator will automatically pad the image to half the PSF size to ensure valid convolution. This is done by default, but can be turned off by setting ``psf_pad = False``. This is only relevant if you are using a PSF.
+    - The upsample factor will increase the resolution of the image by the given factor. For example, ``upsample_factor = 2`` will sample the image at double the resolution, then sum back to the original resolution. This is used when a PSF is provided at high resolution than the original image. Not that the when a PSF is used, the upsample_factor must equal the PSF upsampling level.
+    - For arbitrary pixel integration accuracy using the quad_level parameter. This will use Gaussian quadrature to sample the image at a higher resolution, then integrate the image back to the original resolution. This is useful for high accuracy integration of the image, but is not recommended for large images as it will be slow. The quad_level and upsample_factor can be used together to achieve high accuracy integration of the image convolved with a PSF.
+    - A `Pixelated` light source is defined by bilinear interpolation of the provided image. This means that sub-pixel integration is not required for accurate integration of the pixels. However, if you are using a PSF then you should still use upsample_factor (if your PSF is supersampled) to ensure that everything is sampled at the PSF resolution.
 
     """
 

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -6,7 +6,7 @@ from typing import Optional
 import torch
 
 from .simulator import Simulator
-from ..utils import get_meshgrid, get_pixel_quad_integrator_grid, pixel_quad_integrator
+from ..utils import get_meshgrid, gaussian_quadrature_grid, gaussian_quadrature_integrator
 
 
 __all__ = ("Lens_Source",)
@@ -158,14 +158,14 @@ class Lens_Source(Simulator):
             if lens_source:
                 # Source is lensed by the lens mass distribution
                 if quad_level is not None and quad_level > 1:
-                    finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
+                    finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
                         self.pixelscale/self.upsample_factor, *self.grid, quad_level
                     )
                     bx, by = self.lens.raytrace(
                         finegrid_x, finegrid_y, z_s, params
                     )
                     mu_fine = self.source.brightness(bx, by, params)
-                    mu = pixel_quad_integrator(
+                    mu = gaussian_quadrature_integrator(
                         mu_fine, weights
                     )
                 else:
@@ -174,13 +174,13 @@ class Lens_Source(Simulator):
             else:
                 # Source is imaged without lensing
                 if quad_level is not None and quad_level > 1:
-                    finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
+                    finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
                         self.pixelscale/self.upsample_factor, *self.grid, quad_level
                     )
                     mu_fine = self.source.brightness(
                         finegrid_x, finegrid_y, params
                     )
-                    mu = pixel_quad_integrator(
+                    mu = gaussian_quadrature_integrator(
                         mu_fine, weights
                     )
                 else:
@@ -192,13 +192,13 @@ class Lens_Source(Simulator):
         # Sample the lens light
         if lens_light and self.lens_light is not None:
             if quad_level is not None and quad_level > 1:
-                finegrid_x, finegrid_y, weights = get_pixel_quad_integrator_grid(
+                finegrid_x, finegrid_y, weights = gaussian_quadrature_grid(
                     self.pixelscale/self.upsample_factor, *self.grid, quad_level
                 )
                 mu_fine = self.lens_light.brightness(
                     finegrid_x, finegrid_y, params
                 )
-                mu += pixel_quad_integrator(
+                mu += gaussian_quadrature_integrator(
                     mu_fine, weights
                 )
             else:

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -1,11 +1,12 @@
 from math import pi
 from typing import Callable, Optional, Tuple, Union
-from functools import partial
+from functools import partial, lru_cache
 
 import torch
 from torch import Tensor
 from torch.func import jacfwd
 import numpy as np
+from scipy.special import roots_legendre
 
 
 def flip_axis_ratio(q, phi):
@@ -114,6 +115,98 @@ def get_meshgrid(
         / 2
     )
     return torch.meshgrid([xs, ys], indexing="xy")
+
+@lru_cache(maxsize=32)
+def _quad_table(n, p, dtype, device):
+    """
+    from: https://pomax.github.io/bezierinfo/legendre-gauss.html
+
+    Args:
+        n (int): The number of quadrature points in each dimension.
+        p (Tensor): The pixelscale.
+        dtype (torch.dtype): The desired data type of the tensor.
+        device (torch.device): The device on which to create the tensor.
+
+    Returns:
+        Tuple[Tensor, Tensor, Tensor]: The generated meshgrid as a tuple of Tensors.
+    """
+    abscissa, weights = roots_legendre(n)
+
+    w = torch.tensor(weights, dtype=dtype, device=device)
+    a = torch.tensor(abscissa, dtype=dtype, device=device)
+    X, Y = torch.meshgrid(a, a, indexing="xy")
+
+    W = torch.outer(w, w) / 4.0
+
+    X, Y = p @ (torch.stack((X, Y)).view(2, -1) / 2.0)
+
+    return X, Y, W.reshape(-1)
+
+def get_pixel_quad_integrator_grid(
+    pixelscale, 
+    X, 
+    Y, 
+    quad_level = 3, 
+    device=None, 
+    dtype=torch.float32,
+):
+    """
+    Generates a 2D meshgrid for Gaussian quadrature based on the provided pixelscale and dimensions.
+
+    This is the first of a few steps in order to perform a pixel-wise integration using Gaussian quadrature. The full process would look like this:: python
+
+        X, Y = get_meshgrid(pixelscale, nx, ny)
+        Xs, Ys, weight = get_pixel_quad_integrator_grid(pixelscale, X, Y, quad_level)
+        F = your_brightness_function(Xs, Ys, other, parameters)
+        res = pixel_quad_integrator(F, weight)
+
+    Args:
+        pixelscale (float): The scale of the meshgrid in each dimension.
+        X (Tensor): The x-coordinates of the pixel centers.
+        Y (Tensor): The y-coordinates of the pixel centers.
+        quad_level (int): The number of quadrature points in each dimension.
+        device (torch.device, optional): The device on which to create the tensor. Defaults to None.
+        dtype (torch.dtype, optional): The desired data type of the tensor. Defaults to torch.float32.
+
+    Returns:
+        Tuple[Tensor, Tensor]: The generated meshgrid as a tuple of Tensors.
+    """
+
+    # collect gaussian quadrature weights
+    abscissaX, abscissaY, weight = _quad_table(
+        quad_level, pixelscale, dtype, device
+    )
+
+    # Gaussian quadrature evaluation points
+    Xs = torch.repeat_interleave(X[..., None], quad_level ** 2, -1) + abscissaX
+    Ys = torch.repeat_interleave(Y[..., None], quad_level ** 2, -1) + abscissaY
+    return Xs, Ys, weight
+
+def pixel_quad_integrator(
+    F,
+    weight,
+):
+    """
+    Performs a pixel-wise integration using Gaussian quadrature.
+
+    This is the last of a few steps in order to perform a pixel-wise integration using Gaussian quadrature. The full process would look like this:: python
+
+        X, Y = get_meshgrid(pixelscale, nx, ny)
+        Xs, Ys, weight = get_pixel_quad_integrator_grid(pixelscale, X, Y, quad_level)
+        F = your_brightness_function(Xs, Ys, other, parameters)
+        res = pixel_quad_integrator(F, weight)
+
+    Args:
+        F (Tensor): The brightness function evaluated at the quadrature points.
+        weight (Tensor): The quadrature weights as provided by the get_pixel_quad_integrator_grid function.
+
+    Returns:
+        Tensor: The integrated brightness function at each pixel.
+    """
+
+    # Apply the weights and reduce to original pixel space
+    res = (F * weight).sum(axis=-1)
+    return res
 
 
 def safe_divide(num, denom, places=7):

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -148,7 +148,7 @@ def _quad_table(n, p, dtype, device):
     X, Y = X.reshape(-1), Y.reshape(-1) # flatten
     return X, Y, W.reshape(-1)
 
-def get_pixel_quad_integrator_grid(
+def gaussian_quadrature_grid(
     pixelscale, 
     X, 
     Y, 
@@ -184,9 +184,9 @@ def get_pixel_quad_integrator_grid(
     Usage would look something like:: python
 
         X, Y = get_meshgrid(pixelscale, nx, ny)
-        Xs, Ys, weight = get_pixel_quad_integrator_grid(pixelscale, X, Y, quad_level)
+        Xs, Ys, weight = gaussian_quadrature_grid(pixelscale, X, Y, quad_level)
         F = your_brightness_function(Xs, Ys, other, parameters)
-        res = pixel_quad_integrator(F, weight)
+        res = gaussian_quadrature_integrator(F, weight)
     """
 
     # collect gaussian quadrature weights
@@ -199,7 +199,7 @@ def get_pixel_quad_integrator_grid(
     Ys = torch.repeat_interleave(Y[..., None], quad_level ** 2, -1) + abscissaY
     return Xs, Ys, weight
 
-def pixel_quad_integrator(
+def gaussian_quadrature_integrator(
     F: Tensor,
     weight: Tensor,
 ):
@@ -227,9 +227,9 @@ def pixel_quad_integrator(
     Usage would look something like:: python
 
         X, Y = get_meshgrid(pixelscale, nx, ny)
-        Xs, Ys, weight = get_pixel_quad_integrator_grid(pixelscale, X, Y, quad_level)
+        Xs, Ys, weight = gaussian_quadrature_grid(pixelscale, X, Y, quad_level)
         F = your_brightness_function(Xs, Ys, other, parameters)
-        res = pixel_quad_integrator(F, weight)
+        res = gaussian_quadrature_integrator(F, weight)
     """
     
     return (F * weight).sum(axis=-1)

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -249,19 +249,28 @@ def quad(
 
     Parameters
     ----------
-        F (Callable): The brightness function to be evaluated at the quadrature points. The function should take as input: F(X, Y, *args).
-        pixelscale (float): The scale of each pixel.
-        X (Tensor): The x-coordinates of the pixels.
-        Y (Tensor): The y-coordinates of the pixels.
-        quad_level (int, optional): The level of quadrature to use. Defaults to 3.
-        device (torch.device, optional): The device to perform the computation on. Defaults to None.
-        dtype (torch.dtype, optional): The data type of the computation. Defaults to torch.float32.
+    F : Callable
+        The brightness function to be evaluated at the quadrature points. The function should take as input: F(X, Y, *args).
+    pixelscale : float
+        The scale of each pixel.
+    X : Tensor
+        The x-coordinates of the pixels.
+    Y : Tensor
+        The y-coordinates of the pixels.
+    args : Optional[Tuple], optional
+        Additional arguments to be passed to the brightness function, by default None.
+    quad_level : int, optional
+        The level of quadrature to use, by default 3.
+    device : torch.device, optional
+        The device to perform the computation on, by default None.
+    dtype : torch.dtype, optional
+        The data type of the computation, by default torch.float32.
 
     Returns
     -------
-        Tensor: The integrated brightness function at each pixel.
+    Tensor
+        The integrated brightness function at each pixel.
     """
-
     X, Y, weight = gaussian_quadrature_grid(
         pixelscale, X, Y, quad_level, device, dtype
     )

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -245,9 +245,10 @@ def quad(
     dtype=torch.float32,
     ):
     """
-    Performs a pixel-wise integration using Gaussian quadrature.
+    Performs a pixel-wise integration on a function using Gaussian quadrature.
 
-    Parameters:
+    Parameters
+    ----------
         F (Callable): The brightness function to be evaluated at the quadrature points. The function should take as input: F(X, Y, *args).
         pixelscale (float): The scale of each pixel.
         X (Tensor): The x-coordinates of the pixels.
@@ -256,7 +257,8 @@ def quad(
         device (torch.device, optional): The device to perform the computation on. Defaults to None.
         dtype (torch.dtype, optional): The data type of the computation. Defaults to torch.float32.
 
-    Returns:
+    Returns
+    -------
         Tensor: The integrated brightness function at each pixel.
     """
 

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -133,13 +133,12 @@ def _quad_table(n, p, dtype, device):
     abscissa, weights = roots_legendre(n)
 
     w = torch.tensor(weights, dtype=dtype, device=device)
-    a = torch.tensor(abscissa, dtype=dtype, device=device)
+    a = p * torch.tensor(abscissa, dtype=dtype, device=device) / 2.0
     X, Y = torch.meshgrid(a, a, indexing="xy")
 
     W = torch.outer(w, w) / 4.0
 
-    X, Y = p @ (torch.stack((X, Y)).view(2, -1) / 2.0)
-
+    X, Y = X.reshape(-1), Y.reshape(-1) # flatten
     return X, Y, W.reshape(-1)
 
 def get_pixel_quad_integrator_grid(

--- a/src/caustics/utils.py
+++ b/src/caustics/utils.py
@@ -234,6 +234,38 @@ def gaussian_quadrature_integrator(
     
     return (F * weight).sum(axis=-1)
 
+def quad(
+    F: Callable, 
+    pixelscale: float, 
+    X: Tensor, 
+    Y: Tensor,
+    args: Optional[Tuple] = None,
+    quad_level: int = 3, 
+    device=None, 
+    dtype=torch.float32,
+    ):
+    """
+    Performs a pixel-wise integration using Gaussian quadrature.
+
+    Parameters:
+        F (Callable): The brightness function to be evaluated at the quadrature points. The function should take as input: F(X, Y, *args).
+        pixelscale (float): The scale of each pixel.
+        X (Tensor): The x-coordinates of the pixels.
+        Y (Tensor): The y-coordinates of the pixels.
+        quad_level (int, optional): The level of quadrature to use. Defaults to 3.
+        device (torch.device, optional): The device to perform the computation on. Defaults to None.
+        dtype (torch.dtype, optional): The data type of the computation. Defaults to torch.float32.
+
+    Returns:
+        Tensor: The integrated brightness function at each pixel.
+    """
+
+    X, Y, weight = gaussian_quadrature_grid(
+        pixelscale, X, Y, quad_level, device, dtype
+    )
+    F = F(X, Y, *args)
+    return gaussian_quadrature_integrator(F, weight)
+
 
 def safe_divide(num, denom, places=7):
     """

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -42,7 +42,7 @@ def test_simulator_runs():
         z_s=2.0,
     )
 
-    assert torch.all(torch.isfinite(sim()))
+    assert torch.all(torch.isfinite(sim(quad_level=3)))
     assert torch.all(
         torch.isfinite(
             sim(

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -42,7 +42,7 @@ def test_simulator_runs():
         z_s=2.0,
     )
 
-    assert torch.all(torch.isfinite(sim(quad_level=3)))
+    assert torch.all(torch.isfinite(sim()))
     assert torch.all(
         torch.isfinite(
             sim(
@@ -87,3 +87,9 @@ def test_simulator_runs():
             )
         )
     )
+
+    # Check quadrature integration is accurate
+    assert torch.allclose(sim(), sim(quad_level=3), rtol = 1e-1)
+    assert torch.allclose(sim(quad_level=3), sim(quad_level=5), rtol = 1e-2)
+
+


### PR DESCRIPTION
A gaussian quadrature integrator allows for pixel brightnesses to be more accurately determined with fewer evaluations than simple supersampling. See further information on Gaussian quadrature here: https://en.wikipedia.org/wiki/Gaussian_quadrature