### PR TITLE
ci: Add test command for cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,14 +70,14 @@ jobs:
           echo "=== Testing wheel file ==="
           # Install wheel to get dependencies and check import
           python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre caustics
-          python -c "import caustics; print(caustics.__version__)"
+          python -c "import caustics; print(caustics.__version__); caustics.test()"
           echo "=== Done testing wheel file ==="
 
           echo "=== Testing source tar file ==="
           # Install tar gz and check import
           python -m pip uninstall --yes caustics
           python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre --no-binary=:all: caustics
-          python -c "import caustics; print(caustics.__version__)"
+          python -c "import caustics; print(caustics.__version__); caustics.test()"
           echo "=== Done testing source tar file ==="
 
   publish:


### PR DESCRIPTION
Use the new `caustics.test` command to ensure proper install.