### PR TITLE
docs: Update tutorials to call modules with new paths

### DIFF
--- a/docs/source/tutorials/BasicIntroduction.ipynb
+++ b/docs/source/tutorials/BasicIntroduction.ipynb
@@ -173,11 +173,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -187,8 +182,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/BasicIntroduction.ipynb
+++ b/docs/source/tutorials/BasicIntroduction.ipynb
@@ -38,7 +38,7 @@
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -46,7 +46,7 @@
     ")\n",
     "z_l = torch.tensor(0.5, dtype=torch.float32)\n",
     "z_s = torch.tensor(1.5, dtype=torch.float32)\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)"
    ]
   },
@@ -68,7 +68,7 @@
     "# demo simulator with sersic source, SIE lens. then sample some examples. demo the model graph\n",
     "\n",
     "\n",
-    "class Simple_Sim(caustics.Simulator):\n",
+    "class Simple_Sim(caustics.sims.Simulator):\n",
     "    def __init__(\n",
     "        self,\n",
     "        lens,\n",
@@ -173,6 +173,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -182,7 +187,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/InvertLensEquation.ipynb
+++ b/docs/source/tutorials/InvertLensEquation.ipynb
@@ -42,13 +42,13 @@
    "source": [
     "# initialization stuff for an SIE lens\n",
     "\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)\n",
     "n_pix = 100\n",
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -56,7 +56,7 @@
     ")\n",
     "z_l = torch.tensor(0.5, dtype=torch.float32)\n",
     "z_s = torch.tensor(1.5, dtype=torch.float32)\n",
-    "lens = caustics.SIE(\n",
+    "lens = caustics.lenses.SIE(\n",
     "    cosmology=cosmology,\n",
     "    name=\"sie\",\n",
     "    z_l=z_l,\n",
@@ -128,6 +128,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -137,7 +142,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/InvertLensEquation.ipynb
+++ b/docs/source/tutorials/InvertLensEquation.ipynb
@@ -128,11 +128,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -142,8 +137,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/LensZoo.ipynb
+++ b/docs/source/tutorials/LensZoo.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)\n",
     "z_s = torch.tensor(1.0)\n",
     "base_sersic = caustics.light.Sersic(\n",
@@ -55,7 +55,7 @@
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -500,6 +500,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -509,7 +514,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/LensZoo.ipynb
+++ b/docs/source/tutorials/LensZoo.ipynb
@@ -500,11 +500,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -514,8 +509,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/MultiplaneDemo.ipynb
+++ b/docs/source/tutorials/MultiplaneDemo.ipynb
@@ -231,11 +231,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -245,8 +240,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/MultiplaneDemo.ipynb
+++ b/docs/source/tutorials/MultiplaneDemo.ipynb
@@ -40,13 +40,13 @@
    "outputs": [],
    "source": [
     "# initialization stuff for lenses\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)\n",
     "n_pix = 100\n",
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -73,7 +73,7 @@
     "\n",
     "    for _ in range(N_lenses):\n",
     "        lenses.append(\n",
-    "            caustics.PseudoJaffe(\n",
+    "            caustics.lenses.PseudoJaffe(\n",
     "                cosmology=cosmology,\n",
     "                z_l=z_p,\n",
     "                x0=torch.tensor(np.random.uniform(-fov / 3.0, fov / 3.0)),\n",
@@ -231,6 +231,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -240,7 +245,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/Playground.ipynb
+++ b/docs/source/tutorials/Playground.ipynb
@@ -218,11 +218,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -232,8 +227,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/Playground.ipynb
+++ b/docs/source/tutorials/Playground.ipynb
@@ -41,7 +41,7 @@
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -49,7 +49,7 @@
     ")\n",
     "z_l = torch.tensor(0.5, dtype=torch.float32)\n",
     "z_s = torch.tensor(1.5, dtype=torch.float32)\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)"
    ]
   },
@@ -218,6 +218,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -227,7 +232,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/Simulators.ipynb
+++ b/docs/source/tutorials/Simulators.ipynb
@@ -41,7 +41,7 @@
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -49,7 +49,7 @@
     ")\n",
     "z_l = torch.tensor(0.5, dtype=torch.float32)\n",
     "z_s = torch.tensor(1.5, dtype=torch.float32)\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)"
    ]
   },
@@ -63,7 +63,7 @@
     "# demo simulator with sersic source, SIE lens. then sample some examples. demo the model graph\n",
     "\n",
     "\n",
-    "class Simple_Sim(caustics.Simulator):\n",
+    "class Simple_Sim(caustics.sims.Simulator):\n",
     "    def __init__(\n",
     "        self,\n",
     "        lens,\n",
@@ -262,6 +262,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -271,7 +276,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/Simulators.ipynb
+++ b/docs/source/tutorials/Simulators.ipynb
@@ -262,11 +262,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -276,8 +271,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/VisualizeCaustics.ipynb
+++ b/docs/source/tutorials/VisualizeCaustics.ipynb
@@ -147,11 +147,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -161,8 +156,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/VisualizeCaustics.ipynb
+++ b/docs/source/tutorials/VisualizeCaustics.ipynb
@@ -42,14 +42,14 @@
    "source": [
     "# initialization stuff for an SIE lens\n",
     "\n",
-    "cosmology = caustics.FlatLambdaCDM(name=\"cosmo\")\n",
+    "cosmology = caustics.cosmology.FlatLambdaCDM(name=\"cosmo\")\n",
     "cosmology.to(dtype=torch.float32)\n",
     "sie = caustics.lenses.SIE(cosmology, name=\"sie\")\n",
     "n_pix = 100\n",
     "res = 0.05\n",
     "upsample_factor = 2\n",
     "fov = res * n_pix\n",
-    "thx, thy = caustics.get_meshgrid(\n",
+    "thx, thy = caustics.utils.get_meshgrid(\n",
     "    res / upsample_factor,\n",
     "    upsample_factor * n_pix,\n",
     "    upsample_factor * n_pix,\n",
@@ -147,6 +147,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -156,7 +161,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
With the new import hierarchy, some links in the tutorials were broken. Now they link correctly.