### PR TITLE
ci: Add matplotlib import in RTD pre_build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -30,6 +30,9 @@ build:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx docs/source/"
+      # Create font cache ahead of jupyter book
+      - "python -c 'import matplotlib.pyplot as plt'"
+      # Get the API documentation dynamically
       - "sphinx-apidoc -f -o docs/source/ src/caustics/"
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -31,7 +31,7 @@ build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx docs/source/"
       # Create font cache ahead of jupyter book
-      - "python -c 'import matplotlib.pyplot as plt'"
+      - 'python -c "import matplotlib.pyplot as plt"'
       # Get the API documentation dynamically
       - "sphinx-apidoc -f -o docs/source/ src/caustics/"
 


### PR DESCRIPTION
Add matplotlib import in the beginning to avoid creation of font cache during building of jupyter notebooks.