### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: "23.11.0"
+    rev: "23.12.1"
     hooks:
       - id: black-jupyter
 
@@ -43,21 +43,21 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.4"
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.7"
+    rev: "v0.1.9"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
 
   # 2023-12-11: Not use mypy for now.
   # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: "v1.7.1"
+  #   rev: "v1.8.0"
   #   hooks:
   #     - id: mypy
   #       files: src|tests


### PR DESCRIPTION
These updates is similar to https://github.com/Ciela-Institute/caustics/pull/135 but based from `dev` branch.