### PR TITLE
chore: Bump actions download and upload artifact to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build sdist and wheel
         run: pipx run build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist
 
@@ -48,7 +48,7 @@ jobs:
         name: Install Python
         with:
           python-version: "3.10"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
@@ -90,7 +90,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
This merge together the PRs: https://github.com/Ciela-Institute/caustics/pull/133 and https://github.com/Ciela-Institute/caustics/pull/132 from dependabot, however this is based on current `dev`.