### PR TITLE
feat: Add functionality to build simulator from a YAML configuration file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dev = [
     "lenstronomy==1.11.1",
     "pytest>=8.0,<9",
     "pytest-cov>=4.1,<5",
-    "pre-commit>=3.6,<4"
+    "pytest-mock>=3.12,<4",
+    "pre-commit>=3.6,<4",
 ]
 
 [tool.hatch.metadata.hooks.requirements_txt]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astropy>=5.2.1,<6.0.0
 graphviz==0.20.1
 h5py>=3.8.0
 numpy>=1.23.5
+pydantic>=2.6.1,<3
 safetensors>=0.4.1
 scipy>=1.8.0
 torch>=2.0.0

--- a/src/caustics/__init__.py
+++ b/src/caustics/__init__.py
@@ -28,6 +28,7 @@ from .data import HDF5Dataset, IllustrisKappaDataset, PROBESDataset
 from . import utils
 from .sims import Lens_Source, Simulator
 from .tests import test
+from .models.api import build_simulator
 
 __version__ = VERSION
 __author__ = "Ciela"
@@ -62,4 +63,5 @@ __all__ = [
     "Lens_Source",
     "Simulator",
     "test",
+    "build_simulator",
 ]

--- a/src/caustics/cosmology/FlatLambdaCDM.py
+++ b/src/caustics/cosmology/FlatLambdaCDM.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="operator"
-from typing import Optional
+from typing import Optional, Annotated
 
 import torch
 from torch import Tensor
@@ -11,9 +11,7 @@ from ..utils import interp1d
 from ..parametrized import unpack
 from ..packed import Packed
 from ..constants import c_Mpc_s, km_to_Mpc
-from .base import (
-    Cosmology,
-)
+from .base import Cosmology, NameType
 
 _h0_default = float(default_cosmology.get().h)
 _critical_density_0_default = float(
@@ -41,27 +39,16 @@ class FlatLambdaCDM(Cosmology):
     cosmology with no radiation.
     """
 
-    _meta_params = {
-        "h0": {
-            "default": _h0_default,
-            "description": "Hubble constant over 100",
-        },
-        "critical_density_0": {
-            "default": _critical_density_0_default,
-            "description": "Critical density at z=0",
-        },
-        "Om0": {
-            "default": _Om0_default,
-            "description": "Matter density parameter at z=0",
-        },
-    }
-
     def __init__(
         self,
-        h0: Optional[Tensor] = h0_default,
-        critical_density_0: Optional[Tensor] = critical_density_0_default,
-        Om0: Optional[Tensor] = Om0_default,
-        name: Optional[str] = None,
+        h0: Annotated[Optional[Tensor], "Hubble constant over 100", True] = h0_default,
+        critical_density_0: Annotated[
+            Optional[Tensor], "Critical density at z=0", True
+        ] = critical_density_0_default,
+        Om0: Annotated[
+            Optional[Tensor], "Matter density parameter at z=0", True
+        ] = Om0_default,
+        name: NameType = None,
     ):
         """
         Initialize a new instance of the FlatLambdaCDM class.

--- a/src/caustics/cosmology/FlatLambdaCDM.py
+++ b/src/caustics/cosmology/FlatLambdaCDM.py
@@ -41,6 +41,21 @@ class FlatLambdaCDM(Cosmology):
     cosmology with no radiation.
     """
 
+    _meta_params = {
+        "h0": {
+            "default": _h0_default,
+            "description": "Hubble constant over 100",
+        },
+        "critical_density_0": {
+            "default": _critical_density_0_default,
+            "description": "Critical density at z=0",
+        },
+        "Om0": {
+            "default": _Om0_default,
+            "description": "Matter density parameter at z=0",
+        },
+    }
+
     def __init__(
         self,
         h0: Optional[Tensor] = h0_default,

--- a/src/caustics/cosmology/base.py
+++ b/src/caustics/cosmology/base.py
@@ -1,13 +1,15 @@
 # mypy: disable-error-code="operator"
 from abc import abstractmethod
 from math import pi
-from typing import Optional
+from typing import Optional, Annotated
 
 from torch import Tensor
 
 from ..constants import G_over_c2
 from ..parametrized import Parametrized, unpack
 from ..packed import Packed
+
+NameType = Annotated[Optional[str], "Name of the cosmology"]
 
 
 class Cosmology(Parametrized):
@@ -30,7 +32,7 @@ class Cosmology(Parametrized):
         Name of the cosmological model.
     """
 
-    def __init__(self, name: Optional[str] = None):
+    def __init__(self, name: NameType = None):
         """
         Initialize the Cosmology.
 

--- a/src/caustics/lenses/base.py
+++ b/src/caustics/lenses/base.py
@@ -604,6 +604,10 @@ class ThinLens(Lens):
 
     """
 
+    _meta_params = {
+        "z_l": {"default": None, "description": "The redshift of the lens."},
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/base.py
+++ b/src/caustics/lenses/base.py
@@ -1,6 +1,6 @@
 # mypy: disable-error-code="call-overload"
 from abc import abstractmethod
-from typing import Optional, Union
+from typing import Optional, Union, Annotated, List
 from functools import partial
 import warnings
 
@@ -16,13 +16,21 @@ from ..packed import Packed
 
 __all__ = ("ThinLens", "ThickLens")
 
+CosmologyType = Annotated[
+    Cosmology,
+    "Cosmology object that encapsulates cosmological parameters and distances",
+]
+NameType = Annotated[Optional[str], "Name of the lens model"]
+ZLType = Annotated[Optional[Union[Tensor, float]], "The redshift of the lens", True]
+LensesType = Annotated[List["ThinLens"], "A list of ThinLens objects"]
+
 
 class Lens(Parametrized):
     """
     Base class for all lenses
     """
 
-    def __init__(self, cosmology: Cosmology, name: Optional[str] = None):
+    def __init__(self, cosmology: CosmologyType, name: NameType = None):
         """
         Initializes a new instance of the Lens class.
 
@@ -604,15 +612,11 @@ class ThinLens(Lens):
 
     """
 
-    _meta_params = {
-        "z_l": {"default": None, "description": "The redshift of the lens."},
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        name: NameType = None,
     ):
         super().__init__(cosmology=cosmology, name=name)
         self.add_param("z_l", z_l)

--- a/src/caustics/lenses/epl.py
+++ b/src/caustics/lenses/epl.py
@@ -1,12 +1,11 @@
-# mypy: disable-error-code="operator"
-from typing import Optional, Union
+# mypy: disable-error-code="operator,dict-item"
+from typing import Optional, Union, Annotated
 
 import torch
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import derotate, translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -69,49 +68,35 @@ class EPL(ThinLens):
         "t": 1.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "X coordinate of the lens center.",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "Y coordinate of the lens center.",
-            },
-            "q": {
-                "default": 0.5,
-                "description": "Axis ratio of the lens.",
-            },
-            "phi": {
-                "default": 0.0,
-                "description": "Position angle of the lens.",
-            },
-            "b": {
-                "default": 1.0,
-                "description": "Scale length of the lens.",
-            },
-            "t": {
-                "default": 1.0,
-                "description": "Power law slope of the lens.",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        q: Optional[Union[Tensor, float]] = None,
-        phi: Optional[Union[Tensor, float]] = None,
-        b: Optional[Union[Tensor, float]] = None,
-        t: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        n_iter: int = 18,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]], "X coordinate of the lens center", True
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]], "Y coordinate of the lens center", True
+        ] = None,
+        q: Annotated[
+            Optional[Union[Tensor, float]], "Axis ratio of the lens", True
+        ] = None,
+        phi: Annotated[
+            Optional[Union[Tensor, float]], "Position angle of the lens", True
+        ] = None,
+        b: Annotated[
+            Optional[Union[Tensor, float]], "Scale length of the lens", True
+        ] = None,
+        t: Annotated[
+            Optional[Union[Tensor, float]],
+            "Power law slope (`gamma-1`) of the lens",
+            True,
+        ] = None,
+        s: Annotated[
+            float, "Softening length for the elliptical power-law profile"
+        ] = 0.0,
+        n_iter: Annotated[int, "Number of iterations for the iterative solver"] = 18,
+        name: NameType = None,
     ):
         """
         Initialize an EPL lens model.

--- a/src/caustics/lenses/epl.py
+++ b/src/caustics/lenses/epl.py
@@ -69,6 +69,36 @@ class EPL(ThinLens):
         "t": 1.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "X coordinate of the lens center.",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "Y coordinate of the lens center.",
+            },
+            "q": {
+                "default": 0.5,
+                "description": "Axis ratio of the lens.",
+            },
+            "phi": {
+                "default": 0.0,
+                "description": "Position angle of the lens.",
+            },
+            "b": {
+                "default": 1.0,
+                "description": "Scale length of the lens.",
+            },
+            "t": {
+                "default": 1.0,
+                "description": "Power law slope of the lens.",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/external_shear.py
+++ b/src/caustics/lenses/external_shear.py
@@ -1,10 +1,10 @@
-from typing import Optional, Union
+# mypy: disable-error-code="dict-item"
+from typing import Optional, Union, Annotated
 
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -41,38 +41,30 @@ class ExternalShear(ThinLens):
         "gamma_2": 0.1,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the shear center in the lens plane",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the shear center in the lens plane",
-            },
-            "gamma_1": {
-                "default": 0.1,
-                "description": "Shear component in the x-direction",
-            },
-            "gamma_2": {
-                "default": 0.1,
-                "description": "Shear component in the y-direction",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        gamma_1: Optional[Union[Tensor, float]] = None,
-        gamma_2: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "x-coordinate of the shear center in the lens plane",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "y-coordinate of the shear center in the lens plane",
+            True,
+        ] = None,
+        gamma_1: Annotated[
+            Optional[Union[Tensor, float]], "Shear component in the x-direction", True
+        ] = None,
+        gamma_2: Annotated[
+            Optional[Union[Tensor, float]], "Shear component in the y-direction", True
+        ] = None,
+        s: Annotated[
+            float, "Softening length for the elliptical power-law profile"
+        ] = 0.0,
+        name: NameType = None,
     ):
         super().__init__(cosmology, z_l, name=name)
 

--- a/src/caustics/lenses/external_shear.py
+++ b/src/caustics/lenses/external_shear.py
@@ -41,6 +41,28 @@ class ExternalShear(ThinLens):
         "gamma_2": 0.1,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the shear center in the lens plane",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the shear center in the lens plane",
+            },
+            "gamma_1": {
+                "default": 0.1,
+                "description": "Shear component in the x-direction",
+            },
+            "gamma_2": {
+                "default": 0.1,
+                "description": "Shear component in the y-direction",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/mass_sheet.py
+++ b/src/caustics/lenses/mass_sheet.py
@@ -1,12 +1,11 @@
-# mypy: disable-error-code="operator"
-from typing import Optional, Union
+# mypy: disable-error-code="operator,dict-item"
+from typing import Optional, Union, Annotated
 
 import torch
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -42,32 +41,24 @@ class MassSheet(ThinLens):
         "surface_density": 0.1,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the shear center in the lens plane",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the shear center in the lens plane",
-            },
-            "surface_density": {
-                "default": 0.1,
-                "description": "Surface density",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        surface_density: Optional[Union[Tensor, float]] = None,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "x-coordinate of the shear center in the lens plane",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "y-coordinate of the shear center in the lens plane",
+            True,
+        ] = None,
+        surface_density: Annotated[
+            Optional[Union[Tensor, float]], "Surface density", True
+        ] = None,
+        name: NameType = None,
     ):
         super().__init__(cosmology, z_l, name=name)
 

--- a/src/caustics/lenses/mass_sheet.py
+++ b/src/caustics/lenses/mass_sheet.py
@@ -42,6 +42,24 @@ class MassSheet(ThinLens):
         "surface_density": 0.1,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the shear center in the lens plane",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the shear center in the lens plane",
+            },
+            "surface_density": {
+                "default": 0.1,
+                "description": "Surface density",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/multiplane.py
+++ b/src/caustics/lenses/multiplane.py
@@ -5,8 +5,7 @@ import torch
 from torch import Tensor
 
 from ..constants import arcsec_to_rad, rad_to_arcsec, c_Mpc_s
-from ..cosmology import Cosmology
-from .base import ThickLens, ThinLens
+from .base import ThickLens, NameType, CosmologyType, LensesType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -19,7 +18,7 @@ class Multiplane(ThickLens):
 
     Attributes
     ----------
-    lenses (list[ThinLens])
+    lenses list of ThinLens
         List of thin lenses.
 
     Parameters
@@ -33,7 +32,7 @@ class Multiplane(ThickLens):
     """
 
     def __init__(
-        self, cosmology: Cosmology, lenses: list[ThinLens], name: Optional[str] = None
+        self, cosmology: CosmologyType, lenses: LensesType, name: NameType = None
     ):
         super().__init__(cosmology, name=name)
         self.lenses = lenses

--- a/src/caustics/lenses/nfw.py
+++ b/src/caustics/lenses/nfw.py
@@ -73,6 +73,28 @@ class NFW(ThinLens):
         "c": 5.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the lens center in the lens plane",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the lens center in the lens plane",
+            },
+            "m": {
+                "default": 1e13,
+                "description": "Mass of the lens",
+            },
+            "c": {
+                "default": 5.0,
+                "description": "Concentration parameter of the lens",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/nfw.py
+++ b/src/caustics/lenses/nfw.py
@@ -1,14 +1,13 @@
-# mypy: disable-error-code="operator,union-attr"
+# mypy: disable-error-code="operator,union-attr,dict-item"
 from math import pi
-from typing import Optional, Union
+from typing import Optional, Union, Annotated, Literal
 
 import torch
 from torch import Tensor
 
 from ..constants import G_over_c2, arcsec_to_rad, rad_to_arcsec
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, NameType, CosmologyType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -73,39 +72,28 @@ class NFW(ThinLens):
         "c": 5.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the lens center in the lens plane",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the lens center in the lens plane",
-            },
-            "m": {
-                "default": 1e13,
-                "description": "Mass of the lens",
-            },
-            "c": {
-                "default": 5.0,
-                "description": "Concentration parameter of the lens",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        m: Optional[Union[Tensor, float]] = None,
-        c: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        use_case="batchable",
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]], "X coordinate of the lens center", True
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]], "Y coordinate of the lens center", True
+        ] = None,
+        m: Annotated[Optional[Union[Tensor, float]], "Mass of the lens", True] = None,
+        c: Annotated[
+            Optional[Union[Tensor, float]], "Concentration parameter of the lens", True
+        ] = None,
+        s: Annotated[
+            float,
+            "Softening parameter to avoid singularities at the center of the lens",
+        ] = 0.0,
+        use_case: Annotated[
+            Literal["batchable", "differentiable"], "the NFW/TNFW profile"
+        ] = "batchable",
+        name: NameType = None,
     ):
         """
         Initialize an instance of the NFW lens class.

--- a/src/caustics/lenses/pixelated_convergence.py
+++ b/src/caustics/lenses/pixelated_convergence.py
@@ -1,6 +1,6 @@
-# mypy: disable-error-code="index"
+# mypy: disable-error-code="index,dict-item"
 from math import pi
-from typing import Optional
+from typing import Optional, Annotated, Union, Literal
 
 import torch
 import torch.nn.functional as F
@@ -8,9 +8,8 @@ from scipy.fft import next_fast_len
 from torch import Tensor
 import numpy as np
 
-from ..cosmology import Cosmology
 from ..utils import get_meshgrid, interp2d, safe_divide, safe_log
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -24,38 +23,43 @@ class PixelatedConvergence(ThinLens):
         "convergence_map": np.logspace(0, 1, 100, dtype=np.float32).reshape(10, 10),
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the shear center in the lens plane",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the shear center in the lens plane",
-            },
-            "convergence_map": {
-                "default": np.logspace(0, 1, 100, dtype=np.float32).reshape(10, 10),
-                "description": "The convergence map",
-            },
-        },
-    }
-
     def __init__(
         self,
-        pixelscale: float,
-        n_pix: int,
-        cosmology: Cosmology,
-        z_l: Optional[Tensor] = None,
-        x0: Optional[Tensor] = torch.tensor(0.0),
-        y0: Optional[Tensor] = torch.tensor(0.0),
-        convergence_map: Optional[Tensor] = None,
-        shape: Optional[tuple[int, ...]] = None,
-        convolution_mode: str = "fft",
-        use_next_fast_len: bool = True,
-        padding: str = "zero",
-        name: Optional[str] = None,
+        pixelscale: Annotated[float, "pixelscale"],
+        n_pix: Annotated[int, "The number of pixels on each side of the grid"],
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The x-coordinate of the center of the grid",
+            True,
+        ] = torch.tensor(0.0),
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The y-coordinate of the center of the grid",
+            True,
+        ] = torch.tensor(0.0),
+        convergence_map: Annotated[
+            Optional[Tensor],
+            "A 2D tensor representing the convergence map",
+            True,
+        ] = None,
+        shape: Annotated[
+            Optional[tuple[int, ...]], "The shape of the convergence map"
+        ] = None,
+        convolution_mode: Annotated[
+            Literal["fft", "conv2d"],
+            "The convolution mode for calculating deflection angles and lensing potential",
+        ] = "fft",
+        use_next_fast_len: Annotated[
+            bool,
+            "If True, adds additional padding to speed up the FFT by calling `scipy.fft.next_fast_len`",
+        ] = True,
+        padding: Annotated[
+            Literal["zero", "circular", "reflect", "tile"],
+            "Specifies the type of padding",
+        ] = "zero",
+        name: NameType = None,
     ):
         """Strong lensing with user provided kappa map
 

--- a/src/caustics/lenses/pixelated_convergence.py
+++ b/src/caustics/lenses/pixelated_convergence.py
@@ -24,6 +24,24 @@ class PixelatedConvergence(ThinLens):
         "convergence_map": np.logspace(0, 1, 100, dtype=np.float32).reshape(10, 10),
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the shear center in the lens plane",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the shear center in the lens plane",
+            },
+            "convergence_map": {
+                "default": np.logspace(0, 1, 100, dtype=np.float32).reshape(10, 10),
+                "description": "The convergence map",
+            },
+        },
+    }
+
     def __init__(
         self,
         pixelscale: float,

--- a/src/caustics/lenses/point.py
+++ b/src/caustics/lenses/point.py
@@ -1,12 +1,11 @@
-# mypy: disable-error-code="operator"
-from typing import Optional, Union
+# mypy: disable-error-code="operator,dict-item"
+from typing import Optional, Union, Annotated
 
 import torch
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -41,33 +40,27 @@ class Point(ThinLens):
         "th_ein": 1.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the center of the lens",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the center of the lens",
-            },
-            "th_ein": {
-                "default": 1.0,
-                "description": "Einstein radius of the lens",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        th_ein: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "X coordinate of the center of the lens",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "Y coordinate of the center of the lens",
+            True,
+        ] = None,
+        th_ein: Annotated[
+            Optional[Union[Tensor, float]], "Einstein radius of the lens", True
+        ] = None,
+        s: Annotated[
+            float, "Softening parameter to prevent numerical instabilities"
+        ] = 0.0,
+        name: NameType = None,
     ):
         """
         Initialize the Point class.

--- a/src/caustics/lenses/point.py
+++ b/src/caustics/lenses/point.py
@@ -41,6 +41,24 @@ class Point(ThinLens):
         "th_ein": 1.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the center of the lens",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the center of the lens",
+            },
+            "th_ein": {
+                "default": 1.0,
+                "description": "Einstein radius of the lens",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/pseudo_jaffe.py
+++ b/src/caustics/lenses/pseudo_jaffe.py
@@ -1,14 +1,13 @@
-# mypy: disable-error-code="operator"
+# mypy: disable-error-code="operator,dict-item"
 from math import pi
-from typing import Optional, Union
+from typing import Optional, Union, Annotated
 
 import torch
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..constants import arcsec_to_rad, G_over_c2
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -51,43 +50,36 @@ class PseudoJaffe(ThinLens):
         "scale_radius": 1.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the center of the lens",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the center of the lens",
-            },
-            "mass": {
-                "default": 1e12,
-                "description": "Total mass of the lens (Msol)",
-            },
-            "core_radius": {
-                "default": 0.1,
-                "description": "Core radius of the lens (arcsec)",
-            },
-            "scale_radius": {
-                "default": 1.0,
-                "description": "Scaling radius of the lens (arcsec)",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        mass: Optional[Union[Tensor, float]] = None,
-        core_radius: Optional[Union[Tensor, float]] = None,
-        scale_radius: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "X coordinate of the center of the lens",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "Y coordinate of the center of the lens",
+            True,
+        ] = None,
+        mass: Annotated[
+            Optional[Union[Tensor, float]], "Total mass of the lens", True, "Msol"
+        ] = None,
+        core_radius: Annotated[
+            Optional[Union[Tensor, float]], "Core radius of the lens", True, "arcsec"
+        ] = None,
+        scale_radius: Annotated[
+            Optional[Union[Tensor, float]],
+            "Scaling radius of the lens",
+            True,
+            "arcsec",
+        ] = None,
+        s: Annotated[
+            float, "Softening parameter to prevent numerical instabilities"
+        ] = 0.0,
+        name: NameType = None,
     ):
         """
         Initialize the PseudoJaffe class.

--- a/src/caustics/lenses/pseudo_jaffe.py
+++ b/src/caustics/lenses/pseudo_jaffe.py
@@ -51,6 +51,32 @@ class PseudoJaffe(ThinLens):
         "scale_radius": 1.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the center of the lens",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the center of the lens",
+            },
+            "mass": {
+                "default": 1e12,
+                "description": "Total mass of the lens (Msol)",
+            },
+            "core_radius": {
+                "default": 0.1,
+                "description": "Core radius of the lens (arcsec)",
+            },
+            "scale_radius": {
+                "default": 1.0,
+                "description": "Scaling radius of the lens (arcsec)",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/sie.py
+++ b/src/caustics/lenses/sie.py
@@ -47,6 +47,26 @@ class SIE(ThinLens):
         "b": 1.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "The x-coordinate of the SIE lens's center.",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "The y-coordinate of the SIE lens's center.",
+            },
+            "q": {"default": 0.5, "description": "The axis ratio of the SIE lens"},
+            "phi": {
+                "default": 0.0,
+                "description": "The orientation angle of the SIE lens",
+            },
+            "b": {"default": 1.0, "description": "The Einstein radius of the SIE lens"},
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/sie.py
+++ b/src/caustics/lenses/sie.py
@@ -1,11 +1,10 @@
-# mypy: disable-error-code="operator,union-attr"
-from typing import Optional, Union
+# mypy: disable-error-code="operator,union-attr,dict-item"
+from typing import Optional, Union, Annotated
 
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import derotate, translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -47,37 +46,29 @@ class SIE(ThinLens):
         "b": 1.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "The x-coordinate of the SIE lens's center.",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "The y-coordinate of the SIE lens's center.",
-            },
-            "q": {"default": 0.5, "description": "The axis ratio of the SIE lens"},
-            "phi": {
-                "default": 0.0,
-                "description": "The orientation angle of the SIE lens",
-            },
-            "b": {"default": 1.0, "description": "The Einstein radius of the SIE lens"},
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        q: Optional[Union[Tensor, float]] = None,  # TODO change to true axis ratio
-        phi: Optional[Union[Tensor, float]] = None,
-        b: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]], "The x-coordinate of the lens center", True
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]], "The y-coordinate of the lens center", True
+        ] = None,
+        q: Annotated[
+            Optional[Union[Tensor, float]], "The axis ratio of the lens", True
+        ] = None,  # TODO change to true axis ratio
+        phi: Annotated[
+            Optional[Union[Tensor, float]],
+            "The orientation angle of the lens (position angle)",
+            True,
+        ] = None,
+        b: Annotated[
+            Optional[Union[Tensor, float]], "The Einstein radius of the lens", True
+        ] = None,
+        s: Annotated[float, "The core radius of the lens"] = 0.0,
+        name: NameType = None,
     ):
         """
         Initialize the SIE lens model.

--- a/src/caustics/lenses/singleplane.py
+++ b/src/caustics/lenses/singleplane.py
@@ -3,8 +3,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-from ..cosmology import Cosmology
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, LensesType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -28,15 +27,15 @@ class SinglePlane(ThinLens):
 
     def __init__(
         self,
-        cosmology: Cosmology,
-        lenses: list[ThinLens],
-        name: Optional[str] = None,
-        **kwargs,
+        cosmology: CosmologyType,
+        lenses: LensesType,
+        name: NameType = None,
+        z_l: ZLType = None,
     ):
         """
         Initialize the SinglePlane lens model.
         """
-        super().__init__(cosmology, name=name, **kwargs)
+        super().__init__(cosmology, z_l=z_l, name=name)
         self.lenses = lenses
         for lens in lenses:
             self.add_parametrized(lens)

--- a/src/caustics/lenses/sis.py
+++ b/src/caustics/lenses/sis.py
@@ -1,11 +1,10 @@
-# mypy: disable-error-code="operator"
-from typing import Optional, Union
+# mypy: disable-error-code="operator,dict-item"
+from typing import Optional, Union, Annotated
 
 from torch import Tensor
 
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -29,7 +28,8 @@ class SIS(ThinLens):
         The x-coordinate of the lens center.
     y0: Optional[Union[Tensor, float]]
         The y-coordinate of the lens center.
-        th_ein (Optional[Union[Tensor, float]]): The Einstein radius of the lens.
+    th_ein: Optional[Union[Tensor, float]]
+        The Einstein radius of the lens.
     s: float
         A smoothing factor, default is 0.0.
     """
@@ -40,33 +40,21 @@ class SIS(ThinLens):
         "th_ein": 1.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the center of the lens",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the center of the lens",
-            },
-            "th_ein": {
-                "default": 1.0,
-                "description": "Einstein radius of the lens",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        th_ein: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]], "The x-coordinate of the lens center", True
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]], "The y-coordinate of the lens center", True
+        ] = None,
+        th_ein: Annotated[
+            Optional[Union[Tensor, float]], "The Einstein radius of the lens", True
+        ] = None,
+        s: Annotated[float, "A smoothing factor"] = 0.0,
+        name: NameType = None,
     ):
         """
         Initialize the SIS lens model.

--- a/src/caustics/lenses/sis.py
+++ b/src/caustics/lenses/sis.py
@@ -40,6 +40,24 @@ class SIS(ThinLens):
         "th_ein": 1.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the center of the lens",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the center of the lens",
+            },
+            "th_ein": {
+                "default": 1.0,
+                "description": "Einstein radius of the lens",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/lenses/tnfw.py
+++ b/src/caustics/lenses/tnfw.py
@@ -1,14 +1,13 @@
-# mypy: disable-error-code="operator,union-attr"
+# mypy: disable-error-code="operator,union-attr,dict-item"
 from math import pi
-from typing import Optional, Union
+from typing import Optional, Union, Literal, Annotated
 
 import torch
 from torch import Tensor
 
 from ..constants import G_over_c2, arcsec_to_rad, rad_to_arcsec
-from ..cosmology import Cosmology
 from ..utils import translate_rotate
-from .base import ThinLens
+from .base import ThinLens, CosmologyType, NameType, ZLType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -84,45 +83,48 @@ class TNFW(ThinLens):
         "tau": 3.0,
     }
 
-    _meta_params = {
-        **ThinLens._meta_params,
-        **{
-            "x0": {
-                "default": 0.0,
-                "description": "x-coordinate of the center of the lens",
-            },
-            "y0": {
-                "default": 0.0,
-                "description": "y-coordinate of the center of the lens",
-            },
-            "mass": {
-                "default": 1e13,
-                "description": "Mass of the lens (Msol)",
-            },
-            "scale_radius": {
-                "default": 1.0,
-                "description": "Scale radius of the TNFW lens (arcsec)",
-            },
-            "tau": {
-                "default": 3.0,
-                "description": "Truncation scale. Ratio of truncation radius to scale radius (rt/rs)",
-            },
-        },
-    }
-
     def __init__(
         self,
-        cosmology: Cosmology,
-        z_l: Optional[Union[Tensor, float]] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        mass: Optional[Union[Tensor, float]] = None,
-        scale_radius: Optional[Union[Tensor, float]] = None,
-        tau: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        interpret_m_total_mass: bool = True,
-        use_case="batchable",
-        name: Optional[str] = None,
+        cosmology: CosmologyType,
+        z_l: ZLType = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "Center of lens position on x-axis",
+            True,
+            "arcsec",
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "Center of lens position on y-axis",
+            True,
+            "arcsec",
+        ] = None,
+        mass: Annotated[
+            Optional[Union[Tensor, float]], "Mass of the lens", True, "Msol"
+        ] = None,
+        scale_radius: Annotated[
+            Optional[Union[Tensor, float]],
+            "Scale radius of the TNFW lens",
+            True,
+            "arcsec",
+        ] = None,
+        tau: Annotated[
+            Optional[Union[Tensor, float]],
+            "Truncation scale. Ratio of truncation radius to scale radius",
+            True,
+            "rt/rs",
+        ] = None,
+        s: Annotated[
+            float,
+            "Softening parameter to avoid singularities at the center of the lens",
+        ] = 0.0,
+        interpret_m_total_mass: Annotated[
+            bool, "Indicates how to interpret the mass variable 'm'"
+        ] = True,
+        use_case: Annotated[
+            Literal["batchable", "differentiable"], "the NFW/TNFW profile"
+        ] = "batchable",
+        name: NameType = None,
     ):
         """
         Initialize an instance of the TNFW lens class.

--- a/src/caustics/lenses/tnfw.py
+++ b/src/caustics/lenses/tnfw.py
@@ -84,6 +84,32 @@ class TNFW(ThinLens):
         "tau": 3.0,
     }
 
+    _meta_params = {
+        **ThinLens._meta_params,
+        **{
+            "x0": {
+                "default": 0.0,
+                "description": "x-coordinate of the center of the lens",
+            },
+            "y0": {
+                "default": 0.0,
+                "description": "y-coordinate of the center of the lens",
+            },
+            "mass": {
+                "default": 1e13,
+                "description": "Mass of the lens (Msol)",
+            },
+            "scale_radius": {
+                "default": 1.0,
+                "description": "Scale radius of the TNFW lens (arcsec)",
+            },
+            "tau": {
+                "default": 3.0,
+                "description": "Truncation scale. Ratio of truncation radius to scale radius (rt/rs)",
+            },
+        },
+    }
+
     def __init__(
         self,
         cosmology: Cosmology,

--- a/src/caustics/light/base.py
+++ b/src/caustics/light/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional
+from typing import Optional, Annotated
 
 from torch import Tensor
 
@@ -7,6 +7,8 @@ from ..parametrized import Parametrized, unpack
 from ..packed import Packed
 
 __all__ = ("Source",)
+
+NameType = Annotated[Optional[str], "Name of the source"]
 
 
 class Source(Parametrized):

--- a/src/caustics/light/pixelated.py
+++ b/src/caustics/light/pixelated.py
@@ -36,6 +36,29 @@ class Pixelated(Source):
         The shape of the source image.
     """
 
+    _meta_params = {
+        "x0": {
+            "default": None,
+            "description": "The x-coordinate of the source image's center.",
+        },
+        "y0": {
+            "default": None,
+            "description": "The y-coordinate of the source image's center.",
+        },
+        "image": {
+            "default": None,
+            "description": "The source image from which brightness values will be interpolated.",
+        },
+        "pixelscale": {
+            "default": None,
+            "description": "The pixelscale of the source image in the lens plane in units of arcsec/pixel.",
+        },
+        "shape": {
+            "default": None,
+            "description": "The shape of the source image.",
+        },
+    }
+
     def __init__(
         self,
         image: Optional[Tensor] = None,

--- a/src/caustics/light/pixelated.py
+++ b/src/caustics/light/pixelated.py
@@ -1,10 +1,10 @@
 # mypy: disable-error-code="union-attr"
-from typing import Optional, Union
+from typing import Optional, Union, Annotated
 
 from torch import Tensor
 
 from ..utils import interp2d
-from .base import Source
+from .base import Source, NameType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -36,37 +36,33 @@ class Pixelated(Source):
         The shape of the source image.
     """
 
-    _meta_params = {
-        "x0": {
-            "default": None,
-            "description": "The x-coordinate of the source image's center.",
-        },
-        "y0": {
-            "default": None,
-            "description": "The y-coordinate of the source image's center.",
-        },
-        "image": {
-            "default": None,
-            "description": "The source image from which brightness values will be interpolated.",
-        },
-        "pixelscale": {
-            "default": None,
-            "description": "The pixelscale of the source image in the lens plane in units of arcsec/pixel.",
-        },
-        "shape": {
-            "default": None,
-            "description": "The shape of the source image.",
-        },
-    }
-
     def __init__(
         self,
-        image: Optional[Tensor] = None,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        pixelscale: Optional[Union[Tensor, float]] = None,
-        shape: Optional[tuple[int, ...]] = None,
-        name: Optional[str] = None,
+        image: Annotated[
+            Optional[Tensor],
+            "The source image from which brightness values will be interpolated.",
+            True,
+        ] = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The x-coordinate of the source image's center.",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The y-coordinate of the source image's center.",
+            True,
+        ] = None,
+        pixelscale: Annotated[
+            Optional[Union[Tensor, float]],
+            "The pixelscale of the source image in the lens plane",
+            True,
+            "arcsec/pixel",
+        ] = None,
+        shape: Annotated[
+            Optional[tuple[int, ...]], "The shape of the source image."
+        ] = None,
+        name: NameType = None,
     ):
         """
         Constructs the `Pixelated` object with the given parameters.

--- a/src/caustics/light/sersic.py
+++ b/src/caustics/light/sersic.py
@@ -43,6 +43,28 @@ class Sersic(Source):
         A flag indicating whether to use lenstronomy to compute the value of k.
     """
 
+    _meta_params = {
+        "x0": {
+            "default": None,
+            "description": "The x-coordinate of the Sersic source's center.",
+        },
+        "y0": {
+            "default": None,
+            "description": "The y-coordinate of the Sersic source's center.",
+        },
+        "q": {"default": None, "description": "The axis ratio of the Sersic source"},
+        "phi": {
+            "default": None,
+            "description": "The orientation of the Sersic source (position angle)",
+        },
+        "n": {
+            "default": None,
+            "description": "The Sersic index, which describes the degree of concentration of the source",
+        },
+        "Re": {"default": None, "description": "The scale length of the Sersic source"},
+        "Ie": {"default": None, "description": "The intensity at the effective radius"},
+    }
+
     def __init__(
         self,
         x0: Optional[Union[Tensor, float]] = None,

--- a/src/caustics/light/sersic.py
+++ b/src/caustics/light/sersic.py
@@ -1,10 +1,10 @@
 # mypy: disable-error-code="operator,union-attr"
-from typing import Optional, Union
+from typing import Optional, Union, Annotated
 
 from torch import Tensor
 
 from ..utils import to_elliptical, translate_rotate
-from .base import Source
+from .base import Source, NameType
 from ..parametrized import unpack
 from ..packed import Packed
 
@@ -43,40 +43,47 @@ class Sersic(Source):
         A flag indicating whether to use lenstronomy to compute the value of k.
     """
 
-    _meta_params = {
-        "x0": {
-            "default": None,
-            "description": "The x-coordinate of the Sersic source's center.",
-        },
-        "y0": {
-            "default": None,
-            "description": "The y-coordinate of the Sersic source's center.",
-        },
-        "q": {"default": None, "description": "The axis ratio of the Sersic source"},
-        "phi": {
-            "default": None,
-            "description": "The orientation of the Sersic source (position angle)",
-        },
-        "n": {
-            "default": None,
-            "description": "The Sersic index, which describes the degree of concentration of the source",
-        },
-        "Re": {"default": None, "description": "The scale length of the Sersic source"},
-        "Ie": {"default": None, "description": "The intensity at the effective radius"},
-    }
-
     def __init__(
         self,
-        x0: Optional[Union[Tensor, float]] = None,
-        y0: Optional[Union[Tensor, float]] = None,
-        q: Optional[Union[Tensor, float]] = None,
-        phi: Optional[Union[Tensor, float]] = None,
-        n: Optional[Union[Tensor, float]] = None,
-        Re: Optional[Union[Tensor, float]] = None,
-        Ie: Optional[Union[Tensor, float]] = None,
-        s: float = 0.0,
-        use_lenstronomy_k=False,
-        name: Optional[str] = None,
+        x0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The x-coordinate of the Sersic source's center",
+            True,
+        ] = None,
+        y0: Annotated[
+            Optional[Union[Tensor, float]],
+            "The y-coordinate of the Sersic source's center",
+            True,
+        ] = None,
+        q: Annotated[
+            Optional[Union[Tensor, float]], "The axis ratio of the Sersic source", True
+        ] = None,
+        phi: Annotated[
+            Optional[Union[Tensor, float]],
+            "The orientation of the Sersic source (position angle)",
+            True,
+        ] = None,
+        n: Annotated[
+            Optional[Union[Tensor, float]],
+            "The Sersic index, which describes the degree of concentration of the source",
+            True,
+        ] = None,
+        Re: Annotated[
+            Optional[Union[Tensor, float]],
+            "The scale length of the Sersic source",
+            True,
+        ] = None,
+        Ie: Annotated[
+            Optional[Union[Tensor, float]],
+            "The intensity at the effective radius",
+            True,
+        ] = None,
+        s: Annotated[float, "A small constant for numerical stability"] = 0.0,
+        use_lenstronomy_k: Annotated[
+            bool,
+            "A flag indicating whether to use lenstronomy to compute the value of k.",
+        ] = False,
+        name: NameType = None,
     ):
         """
         Constructs the `Sersic` object with the given parameters.

--- a/src/caustics/models/api.py
+++ b/src/caustics/models/api.py
@@ -1,0 +1,33 @@
+# mypy: disable-error-code="import-untyped"
+import yaml
+
+from ..sims.simulator import Simulator
+from ..io import from_file
+from .utils import setup_simulator_models, create_model, Field
+from .base_models import StateConfig
+
+
+def build_simulator(config_path: "str") -> Simulator:
+    """
+    Build a simulator from the configuration
+    """
+    simulators = setup_simulator_models()
+    Config = create_model(
+        "Config", __base__=StateConfig, simulator=(simulators, Field(...))
+    )
+
+    # Load the yaml config
+    yaml_bytes = from_file(config_path)
+    config_json = yaml.safe_load(yaml_bytes)
+    # Create config model
+    config = Config(**config_json)
+
+    # Get the simulator
+    sim = config.simulator.model_obj()
+
+    # Load state if available
+    simulator_state = config.state
+    if simulator_state is not None:
+        sim.load_state_dict(simulator_state.load.path)
+
+    return sim

--- a/src/caustics/models/api.py
+++ b/src/caustics/models/api.py
@@ -1,5 +1,7 @@
 # mypy: disable-error-code="import-untyped"
 import yaml
+from pathlib import Path
+from typing import Union
 
 from ..sims.simulator import Simulator
 from ..io import from_file
@@ -7,7 +9,7 @@ from .utils import setup_simulator_models, create_model, Field
 from .base_models import StateConfig
 
 
-def build_simulator(config_path: "str") -> Simulator:
+def build_simulator(config_path: Union[str, Path]) -> Simulator:
     """
     Build a simulator from the configuration
     """

--- a/src/caustics/models/api.py
+++ b/src/caustics/models/api.py
@@ -20,9 +20,9 @@ def build_simulator(config_path: Union[str, Path]) -> Simulator:
 
     # Load the yaml config
     yaml_bytes = from_file(config_path)
-    config_json = yaml.safe_load(yaml_bytes)
+    config_dict = yaml.safe_load(yaml_bytes)
     # Create config model
-    config = Config(**config_json)
+    config = Config(**config_dict)
 
     # Get the simulator
     sim = config.simulator.model_obj()

--- a/src/caustics/models/base_models.py
+++ b/src/caustics/models/base_models.py
@@ -1,0 +1,90 @@
+from typing import Optional, Any, Dict
+from pydantic import BaseModel, Field, ConfigDict
+from ..parametrized import Parametrized
+
+
+class Parameters(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class InitKwargs(Parameters):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class Base(BaseModel):
+    name: str = Field(..., description="Name of the object")
+    kind: str = Field(..., description="Kind of the object")
+    params: Optional[Parameters] = Field(None, description="Parameters of the object")
+    init_kwargs: Optional[InitKwargs] = Field(
+        None, description="Initiation keyword arguments for object creation"
+    )
+
+    # internal
+    _cls: Any
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+    def _get_init_kwargs_dump(self, init_kwargs: InitKwargs) -> Dict[str, Any]:
+        """
+        Get the model dump of the class parameters,
+        if the field is a model then get the model object.
+
+        Parameters
+        ----------
+        init_kwargs : ClassParams
+            The class parameters to dump
+
+        Returns
+        -------
+        dict
+            The model dump of the class parameters
+        """
+        model_dict = {}
+        for f in init_kwargs.model_fields_set:
+            model = getattr(init_kwargs, f)
+            if isinstance(model, Base):
+                model_dict[f] = model.model_obj()
+            elif isinstance(model, list):
+                model_dict[f] = [m.model_obj() for m in model]
+            else:
+                model_dict[f] = getattr(init_kwargs, f)
+        return model_dict
+
+    @classmethod
+    def _set_class(cls, parametrized_cls: Parametrized) -> type["Base"]:
+        """
+        Set the class of the object.
+
+        Parameters
+        ----------
+        cls : Parametrized
+            The class to set.
+        """
+        cls._cls = parametrized_cls
+        return cls
+
+    def model_obj(self) -> Any:
+        if not self._cls:
+            raise ValueError(
+                "The class is not set. Please set the class before calling this method."
+            )
+        init_kwargs = (
+            self._get_init_kwargs_dump(self.init_kwargs) if self.init_kwargs else {}
+        )  # Capture None case
+        params = self.params.model_dump() if self.params else {}  # Capture None case
+        return self._cls(name=self.name, **init_kwargs, **params)
+
+
+class FileInput(BaseModel):
+    path: str = Field(..., description="The path to the file")
+
+
+class StateDict(BaseModel):
+    load: FileInput
+
+
+class StateConfig(BaseModel):
+    state: Optional[StateDict] = Field(
+        None, description="State safetensor for the simulator"
+    )

--- a/src/caustics/models/registry.py
+++ b/src/caustics/models/registry.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from collections import ChainMap, OrderedDict
+from collections import ChainMap
 from typing import MutableMapping, Iterator, Optional
 
 from caustics.parametrized import Parametrized
@@ -31,16 +31,6 @@ class _KindRegistry(MutableMapping[str, "Parametrized | str"]):
         "Sersic": "caustics.light.sersic.Sersic",
     }
     simulators = {"Lens_Source": "caustics.sims.lens_source.Lens_Source"}
-
-    _categories = OrderedDict(
-        [
-            ("cosmology", list(cosmology.keys())),
-            ("single_lenses", list(single_lenses.keys())),
-            ("multi_lenses", list(multi_lenses.keys())),
-            ("light", list(light.keys())),
-            ("simulators", list(simulators.keys())),
-        ]
-    )
 
     known_kinds = {
         **cosmology,

--- a/src/caustics/models/registry.py
+++ b/src/caustics/models/registry.py
@@ -21,9 +21,9 @@ class _KindRegistry(MutableMapping[str, "Parametrized | str"]):
         "SIS": "caustics.lenses.sis.SIS",
         "TNFW": "caustics.lenses.tnfw.TNFW",
         "MassSheet": "caustics.lenses.mass_sheet.MassSheet",
+        "SinglePlane": "caustics.lenses.singleplane.SinglePlane",
     }
     multi_lenses = {
-        "SinglePlane": "caustics.lenses.singleplane.SinglePlane",
         "Multiplane": "caustics.lenses.multiplane.Multiplane",
     }
     light = {

--- a/src/caustics/models/utils.py
+++ b/src/caustics/models/utils.py
@@ -244,7 +244,7 @@ def setup_pydantic_models() -> Tuple[type[Annotated], type[Annotated]]:
         for lens in _registry.multi_lenses
     ]
     lenses = Annotated[
-        Union[tuple([*single_lens_models, *multi_lens_models])],
+        Union[tuple([single_plane_model, *single_lens_models, *multi_lens_models])],
         Field(discriminator="kind"),
     ]
     return light_sources, lenses

--- a/src/caustics/models/utils.py
+++ b/src/caustics/models/utils.py
@@ -156,6 +156,10 @@ def create_pydantic_model(
                             # `caustics.utils.gaussian`
                             func = _import_func_or_class(v["func"])
                             v = func(**v["kwargs"])  # type: ignore
+                        else:
+                            raise ValueError(
+                                f"Dictionary with keys 'func' and 'kwargs' expected, got: {v.keys()}"
+                            )
                     elif expected_type == torch.Tensor:
                         # Try to cast to tensor if expected type is tensor
                         v = torch.as_tensor(v)

--- a/src/caustics/models/utils.py
+++ b/src/caustics/models/utils.py
@@ -149,7 +149,7 @@ def create_pydantic_model(
                 )
                 if not isinstance(v, expected_type):
                     if isinstance(v, dict):
-                        if all(k for k in ["func", "kwargs"]):
+                        if all(k in ["func", "kwargs"] for k in v.keys()):
                             # Special case for the init_kwargs
                             # this is to allow for creating tensor with some
                             # caustics utils function, such as

--- a/src/caustics/models/utils.py
+++ b/src/caustics/models/utils.py
@@ -1,0 +1,256 @@
+# mypy: disable-error-code="union-attr, valid-type, has-type, assignment, arg-type, dict-item, return-value, misc"
+import typing
+from typing import List, Literal, Dict, Annotated, Union, Any, Tuple
+import inspect
+from pydantic import Field, create_model, field_validator, ValidationInfo
+import torch
+
+from ..parametrized import Parametrized
+from .base_models import Base, Parameters, InitKwargs
+from .registry import get_kind, _registry
+from ..parametrized import ClassParam
+from ..utils import _import_func_or_class, _eval_expression
+
+PARAMS = "params"
+INIT_KWARGS = "init_kwargs"
+
+
+def _get_kwargs_field_definitions(
+    parametrized_class: Parametrized, dependant_models: Dict[str, Any] = {}
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Get the field definitions for the parameters and init_kwargs of a Parametrized class
+
+    Parameters
+    ----------
+    parametrized_class : Parametrized
+        The Parametrized class to get the field definitions for.
+    dependant_models : Dict[str, Any], optional
+        The dependent models to use, by default {}
+        See: https://docs.pydantic.dev/latest/concepts/unions/#nested-discriminated-unions
+
+    Returns
+    -------
+    dict
+        The resulting field definitions dictionary
+    """
+    cls_signature = inspect.signature(parametrized_class)
+    kwargs_field_definitions: Dict[str, Dict[str, Any]] = {PARAMS: {}, INIT_KWARGS: {}}
+    for k, v in cls_signature.parameters.items():
+        if k != "name":
+            anno = v.annotation
+            dtype = anno.__origin__
+            cls_param = ClassParam(*anno.__metadata__)
+            if cls_param.isParam:
+                kwargs_field_definitions[PARAMS][k] = (
+                    dtype,
+                    Field(default=v.default, description=cls_param.description),
+                )
+            # Below is to handle cases for init kwargs
+            elif k in dependant_models:
+                dependant_model = dependant_models[k]
+                if isinstance(dependant_model, list):
+                    # For the multi lens case
+                    # dependent model is wrapped in a list
+                    dependant_model = dependant_model[0]
+                    kwargs_field_definitions[INIT_KWARGS][k] = (
+                        List[dependant_model],
+                        Field([], description=cls_param.description),
+                    )
+                else:
+                    kwargs_field_definitions[INIT_KWARGS][k] = (
+                        dependant_model,
+                        Field(..., description=cls_param.description),
+                    )
+            elif v.default == inspect._empty:
+                kwargs_field_definitions[INIT_KWARGS][k] = (
+                    dtype,
+                    Field(..., description=cls_param.description),
+                )
+            else:
+                kwargs_field_definitions[INIT_KWARGS][k] = (
+                    dtype,
+                    Field(v.default, description=cls_param.description),
+                )
+    return kwargs_field_definitions
+
+
+def create_pydantic_model(
+    cls: "Parametrized | str", dependant_models: Dict[str, type] = {}
+) -> Base:
+    """
+    Create a pydantic model from a Parametrized class.
+
+    Parameters
+    ----------
+    cls : Parametrized | str
+        The Parametrized class to create the model from.
+    dependant_models : Dict[str, type], optional
+        The dependent models to use, by default {}
+        See: https://docs.pydantic.dev/latest/concepts/unions/#nested-discriminated-unions
+
+    Returns
+    -------
+    Base
+        The pydantic model of the Parametrized class.
+    """
+    if isinstance(cls, str):
+        parametrized_class = get_kind(cls)  # type: ignore
+
+    # Get the field definitions for parameters and init_kwargs
+    kwargs_field_definitions = _get_kwargs_field_definitions(
+        parametrized_class, dependant_models
+    )
+
+    # Create the model field definitions
+    field_definitions = {
+        "kind": (Literal[parametrized_class.__name__], Field(parametrized_class.__name__)),  # type: ignore
+    }
+
+    if kwargs_field_definitions[PARAMS]:
+
+        def _param_field_tensor_check(cls, v):
+            """Checks the ``params`` fields input
+            and converts to tensor if necessary"""
+            if not isinstance(v, torch.Tensor):
+                if isinstance(v, str):
+                    v = _eval_expression(v)
+                v = torch.as_tensor(v)
+            return v
+
+        # Setup the pydantic models for the parameters and init_kwargs
+        ParamsModel = create_model(
+            f"{parametrized_class.__name__}_Params",
+            __base__=Parameters,
+            __validators__={
+                # Convert to tensor before passing to the model for additional validation
+                "field_tensor_check": field_validator(
+                    "*", mode="before", check_fields=True
+                )(_param_field_tensor_check)
+            },
+            **kwargs_field_definitions[PARAMS],
+        )
+        field_definitions["params"] = (
+            ParamsModel,
+            Field(ParamsModel(), description="Parameters of the object"),
+        )
+
+    if kwargs_field_definitions[INIT_KWARGS]:
+
+        def _init_kwargs_field_check(cls, v, info: ValidationInfo):
+            """Checks the ``init_kwargs`` fields input"""
+            field_name = info.field_name
+            field = cls.model_fields[field_name]
+            anno_args = typing.get_args(field.annotation)
+            if len(anno_args) == 2 and anno_args[1] == type(None):
+                # This means that the anno is optional
+                expected_type = next(
+                    filter(lambda x: x is not None, typing.get_args(field.annotation))
+                )
+                if not isinstance(v, expected_type):
+                    if isinstance(v, dict):
+                        if all(k for k in ["func", "kwargs"]):
+                            # Special case for the init_kwargs
+                            # this is to allow for creating tensor with some
+                            # caustics utils function, such as
+                            # `caustics.utils.gaussian`
+                            func = _import_func_or_class(v["func"])
+                            v = func(**v["kwargs"])  # type: ignore
+                    elif expected_type == torch.Tensor:
+                        # Try to cast to tensor if expected type is tensor
+                        v = torch.as_tensor(v)
+                    else:
+                        # Try to cast to the expected type
+                        v = expected_type(v)
+            return v
+
+        InitKwargsModel = create_model(
+            f"{parametrized_class.__name__}_Init_Kwargs",
+            __base__=InitKwargs,
+            **kwargs_field_definitions[INIT_KWARGS],
+            __validators__={
+                "field_check": field_validator("*", mode="before", check_fields=True)(
+                    _init_kwargs_field_check
+                )
+            },
+        )
+        field_definitions["init_kwargs"] = (
+            InitKwargsModel,
+            Field({}, description="Initiation keyword arguments of the object"),
+        )
+
+    # Create the model
+    model = create_model(
+        parametrized_class.__name__, __base__=Base, **field_definitions
+    )
+    # Set the imported parametrized class to the model
+    # this will be accessible as `model._cls`
+    model = model._set_class(parametrized_class)
+    return model
+
+
+def setup_pydantic_models() -> Tuple[type[Annotated], type[Annotated]]:
+    """
+    Setup the pydantic models for the light sources and lenses.
+
+    Returns
+    -------
+    light_sources : type[Annotated]
+        The annotated union of the light source pydantic models
+    lenses : type[Annotated]
+        The annotated union of the lens pydantic models
+    """
+    # Cosmology
+    cosmology_models = [create_pydantic_model(cosmo) for cosmo in _registry.cosmology]
+    cosmology = Annotated[Union[tuple(cosmology_models)], Field(discriminator="kind")]
+    # Light
+    light_models = [create_pydantic_model(light) for light in _registry.light]
+    light_sources = Annotated[Union[tuple(light_models)], Field(discriminator="kind")]
+    # Single Lens
+    lens_dependant_models = {"cosmology": cosmology}
+    single_lens_models = [
+        create_pydantic_model(lens, dependant_models=lens_dependant_models)
+        for lens in _registry.single_lenses
+    ]
+    single_lenses = Annotated[
+        Union[tuple(single_lens_models)], Field(discriminator="kind")
+    ]
+    # Multi Lens
+    multi_lens_models = [
+        create_pydantic_model(
+            lens, dependant_models={"lenses": [single_lenses], **lens_dependant_models}
+        )
+        for lens in _registry.multi_lenses
+    ]
+    lenses = Annotated[
+        Union[tuple([*single_lens_models, *multi_lens_models])],
+        Field(discriminator="kind"),
+    ]
+    return light_sources, lenses
+
+
+def setup_simulator_models() -> type[Annotated]:
+    """
+    Setup the pydantic models for the simulators
+
+    Returns
+    -------
+    type[Annotated]
+        The annotated union of the simulator pydantic models
+    """
+    light_sources, lenses = setup_pydantic_models()
+    # Hard code the dependants for now
+    # there's currently only one simulator
+    # in the system.
+    dependents = {
+        "Lens_Source": {
+            "source": light_sources,
+            "lens_light": light_sources,
+            "lens": lenses,
+        }
+    }
+    simulators_models = [
+        create_pydantic_model(sim, dependant_models=dependents.get(sim))
+        for sim in _registry.simulators
+    ]
+    return Annotated[Union[tuple(simulators_models)], Field(discriminator="kind")]

--- a/src/caustics/parametrized.py
+++ b/src/caustics/parametrized.py
@@ -1,7 +1,8 @@
 # mypy: disable-error-code="var-annotated,index,type-arg"
 from collections import OrderedDict
 from math import prod
-from typing import Optional, Union, Dict
+from typing import Optional, Union
+from dataclasses import dataclass
 import functools
 import inspect
 
@@ -16,6 +17,13 @@ from .namespace_dict import NamespaceDict, NestedNamespaceDict
 from .parameter import Parameter
 
 __all__ = ("Parametrized", "unpack")
+
+
+@dataclass
+class ClassParam:
+    description: str
+    isParam: bool = False
+    unit: Optional[str] = None
 
 
 def check_valid_name(name):
@@ -59,9 +67,6 @@ class Parametrized:
     n_static: int
         Number of static parameters.
     """
-
-    # Metadata about the parameters
-    _meta_params: Dict = {}
 
     def __init__(self, name: Optional[str] = None):
         if name is None:

--- a/src/caustics/parametrized.py
+++ b/src/caustics/parametrized.py
@@ -1,7 +1,7 @@
 # mypy: disable-error-code="var-annotated,index,type-arg"
 from collections import OrderedDict
 from math import prod
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any
 import functools
 import inspect
 
@@ -59,6 +59,9 @@ class Parametrized:
     n_static: int
         Number of static parameters.
     """
+
+    # Metadata about the parameters
+    _meta_params: Dict[Dict[str, Any]] = {}
 
     def __init__(self, name: Optional[str] = None):
         if name is None:

--- a/src/caustics/parametrized.py
+++ b/src/caustics/parametrized.py
@@ -1,7 +1,7 @@
 # mypy: disable-error-code="var-annotated,index,type-arg"
 from collections import OrderedDict
 from math import prod
-from typing import Optional, Union, Dict, Any
+from typing import Optional, Union, Dict
 import functools
 import inspect
 
@@ -61,7 +61,7 @@ class Parametrized:
     """
 
     # Metadata about the parameters
-    _meta_params: Dict[Dict[str, Any]] = {}
+    _meta_params: Dict = {}
 
     def __init__(self, name: Optional[str] = None):
         if name is None:

--- a/src/caustics/registry.py
+++ b/src/caustics/registry.py
@@ -1,0 +1,112 @@
+from importlib import import_module
+from functools import lru_cache
+from collections import ChainMap
+from typing import MutableMapping, Iterator
+
+from caustics.parametrized import Parametrized
+
+
+class _KindRegistry(MutableMapping[str, Parametrized | str]):
+    known_kinds = {
+        "FlatLambdaCDM": "caustics.cosmology.FlatLambdaCDM.FlatLambdaCDM",
+        "EPL": "caustics.lenses.epl.EPL",
+        "ExternalShear": "caustics.lenses.external_shear.ExternalShear",
+        "PixelatedConvergence": "caustics.lenses.pixelated_convergence.PixelatedConvergence",
+        "SinglePlane": "caustics.lenses.singleplane.SinglePlane",
+        "Multiplane": "caustics.lenses.multiplane.Multiplane",
+        "NFW": "caustics.lenses.nfw.NFW",
+        "Point": "caustics.lenses.point.Point",
+        "PseudoJaffe": "caustics.lenses.pseudo_jaffe.PseudoJaffe",
+        "SIE": "caustics.lenses.sie.SIE",
+        "SIS": "caustics.lenses.sis.SIS",
+        "TNFW": "caustics.lenses.tnfw.TNFW",
+        "MassSheet": "caustics.lenses.mass_sheet.MassSheet",
+        "Pixelated": "caustics.light.pixelated.Pixelated",
+        "Sersic": "caustics.light.sersic.Sersic",
+        "Lens_Source": "caustics.sims.lens_source.Lens_Source",
+    }
+
+    def __init__(self) -> None:
+        self._m: ChainMap[str, Parametrized | str] = ChainMap({}, self.known_kinds)  # type: ignore
+
+    def __getitem__(self, item: str) -> Parametrized:
+        kind_mod: str | Parametrized | None = self._m.get(item, None)
+        if kind_mod is None:
+            raise KeyError(f"{item} not in registry")
+        if isinstance(kind_mod, str):
+            module_name, name = kind_mod.rsplit(".", 1)
+            mod = import_module(module_name)
+            cls = getattr(mod, name)  # type: ignore
+        return cls
+
+    def __setitem__(self, item: str, value: Parametrized | str) -> None:
+        if not (
+            (isinstance(value, type) and issubclass(value, Parametrized))
+            or isinstance(value, str)
+        ):
+            raise ValueError(
+                f"expected Parametrized subclass, got: {type(value).__name__!r}"
+            )
+        self._m[item] = value
+
+    def __delitem__(self, __v: str) -> None:
+        raise NotImplementedError("removal is unsupported")
+
+    def __len__(self) -> int:
+        return len(set(self._m))
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(set(self._m))
+
+
+_registry = _KindRegistry()
+
+
+def available_kinds() -> list[str]:
+    """
+    Return a list of classes that are available in the registry.
+    """
+    return list(_registry)
+
+
+def register_kind(
+    name: str,
+    cls: Parametrized | str,
+    *,
+    clobber: bool = False,
+) -> None:
+    """register a UPath implementation with a protocol
+
+    Parameters
+    ----------
+    name : str
+        Protocol name to associate with the class
+    cls : Parametrized or str
+        The caustics parametrized subclass or a str representing the
+        full path to the class like package.module.class.
+    clobber:
+        Whether to overwrite a protocol with the same name; if False,
+        will raise instead.
+    """
+    if not clobber and name in _registry:
+        raise ValueError(f"{name!r} is already in registry and clobber is False!")
+    _registry[name] = cls
+
+
+@lru_cache
+def get_kind(
+    name: str,
+) -> Parametrized | None:
+    """Get a class from the registry by name.
+
+    Parameters
+    ----------
+    kind : str
+        The name of the kind to get.
+
+    Returns
+    -------
+    cls : Parametrized
+        The class associated with the given name.
+    """
+    return _registry[name]

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -2,15 +2,18 @@ from copy import copy
 
 from scipy.fft import next_fast_len
 from torch.nn.functional import avg_pool2d, conv2d
-from typing import Optional
+from typing import Optional, Annotated, Literal, Union
 import torch
+from torch import Tensor
 
-from .simulator import Simulator
+from .simulator import Simulator, NameType
 from ..utils import (
     get_meshgrid,
     gaussian_quadrature_grid,
     gaussian_quadrature_integrator,
 )
+from ..lenses.base import Lens
+from ..light.base import Source
 
 
 __all__ = ("Lens_Source",)
@@ -42,17 +45,17 @@ class Lens_Source(Simulator):
 
     Attributes
     ----------
-    lens
+    lens: Lens
         caustics lens mass model object
-    source
+    source: Source
         caustics light object which defines the background source
     pixelscale: float
         pixelscale of the sampling grid.
     pixels_x: int
         number of pixels on the x-axis for the sampling grid
-    lens_light: (optional)
+    lens_light: Source, optional
         caustics light object which defines the lensing object's light
-    psf: (optional)
+    psf: Tensor, optional
         An image to convolve with the scene. Note that if ``upsample_factor > 1`` the psf must also be at the higher resolution.
     pixels_y: Optional[int]
         number of pixels on the y-axis for the sampling grid. If left as ``None`` then this will simply be equal to ``gridx``
@@ -74,27 +77,33 @@ class Lens_Source(Simulator):
 
     """  # noqa: E501
 
-    _meta_params = {
-        "z_s": {
-            "default": None,
-            "description": "Redshift of the source",
-        }
-    }
-
     def __init__(
         self,
-        lens,
-        source,
-        pixelscale: float,
-        pixels_x: int,
-        lens_light=None,
-        psf=None,
-        pixels_y: Optional[int] = None,
-        upsample_factor: int = 1,
-        psf_pad=True,
-        psf_mode="fft",
-        z_s=None,
-        name: str = "sim",
+        lens: Annotated[Lens, "caustics lens mass model object"],
+        source: Annotated[
+            Source, "caustics light object which defines the background source"
+        ],
+        pixelscale: Annotated[float, "pixelscale of the sampling grid"],
+        pixels_x: Annotated[
+            int, "number of pixels on the x-axis for the sampling grid"
+        ],
+        lens_light: Annotated[
+            Optional[Source],
+            "caustics light object which defines the lensing object's light",
+        ] = None,
+        psf: Annotated[Optional[Tensor], "An image to convolve with the scene"] = None,
+        pixels_y: Annotated[
+            Optional[int], "number of pixels on the y-axis for the sampling grid"
+        ] = None,
+        upsample_factor: Annotated[int, "Amount of upsampling to model the image"] = 1,
+        psf_pad: Annotated[bool, "Flag to apply padding to psf"] = True,
+        psf_mode: Annotated[
+            Literal["fft", "conv2d"], "Mode for convolving psf"
+        ] = "fft",
+        z_s: Annotated[
+            Optional[Union[Tensor, float]], "Redshift of the source", True
+        ] = None,
+        name: NameType = "sim",
     ):
         super().__init__(name)
 

--- a/src/caustics/sims/lens_source.py
+++ b/src/caustics/sims/lens_source.py
@@ -74,6 +74,13 @@ class Lens_Source(Simulator):
 
     """  # noqa: E501
 
+    _meta_params = {
+        "z_s": {
+            "default": None,
+            "description": "Redshift of the source",
+        }
+    }
+
     def __init__(
         self,
         lens,

--- a/src/caustics/sims/simulator.py
+++ b/src/caustics/sims/simulator.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Annotated, Optional
 from torch import Tensor
 
 from ..parametrized import Parametrized
@@ -6,6 +6,8 @@ from .state_dict import StateDict
 from ..namespace_dict import NestedNamespaceDict
 
 __all__ = ("Simulator",)
+
+NameType = Annotated[Optional[str], "Name of the simulator"]
 
 
 class Simulator(Parametrized):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,41 @@ import sys
 import os
 import torch
 import pytest
+import typing
 
 # Add the helpers directory to the path so we can import the helpers
 sys.path.append(os.path.join(os.path.dirname(__file__), "utils"))
 
+from caustics.models.utils import setup_pydantic_models
+
 CUDA_AVAILABLE = torch.cuda.is_available()
+
+LIGHT_ANNOTATED, LENSES_ANNOTATED = setup_pydantic_models()
+
+
+def _get_models(annotated):
+    typehint = typing.get_args(annotated)[0]
+    pydantic_models = typing.get_args(typehint)
+    if isinstance(pydantic_models, tuple):
+        pydantic_models = {m.__name__: m for m in pydantic_models}
+    else:
+        pydantic_models = {pydantic_models.__name__: pydantic_models}
+    return pydantic_models
+
+
+@pytest.fixture
+def light_models():
+    return _get_models(LIGHT_ANNOTATED)
+
+
+@pytest.fixture
+def lens_models():
+    return _get_models(LENSES_ANNOTATED)
+
+
+@pytest.fixture(params=["yaml", "no_yaml"])
+def sim_source(request):
+    return request.param
 
 
 @pytest.fixture(

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -177,7 +177,3 @@ def test_build_simulator_w_state(sim_yaml_file, sim_obj, x_input):
     assert newsim.get_graph(True, True)
     assert isinstance(result, torch.Tensor)
     assert torch.allclose(result, expected_result)
-
-    # Cleanup
-    if os.path.exists(state_path):
-        os.unlink(state_path)

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -1,5 +1,4 @@
 from tempfile import NamedTemporaryFile
-import sys
 import os
 
 import pytest
@@ -102,16 +101,20 @@ def test_complex_build_simulator():
             10.0,
         ]
     )
-    delete_file = False if sys.platform.startswith("win") else True
-    with NamedTemporaryFile("w", delete=delete_file) as f:  # Don't delete for windows
-        f.write(yaml_str)
-        f.flush()
-        sim = caustics.build_simulator(f.name)
-        image = sim(x, quad_level=3)
-        assert isinstance(image, torch.Tensor)
-        f.close()
-        if not delete_file:
-            os.unlink(f.name)
+    # Create temp file
+    f = NamedTemporaryFile("w", delete=False)
+    f.write(yaml_str)
+    f.flush()
+    f.close()
+
+    # Open the temp file and build the simulator
+    sim = caustics.build_simulator(f.name)
+    image = sim(x, quad_level=3)
+    assert isinstance(image, torch.Tensor)
+
+    # Remove the temp file
+    if os.path.exists(f.name):
+        os.unlink(f.name)
 
 
 def test_build_simulator_w_state():

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -49,17 +49,17 @@ def _write_temp_yaml(yaml_str: str):
     f.flush()
     f.close()
 
-    return f
+    return f.name
 
 
 @pytest.fixture
 def sim_yaml_file(sim_yaml):
     temp_file = _write_temp_yaml(sim_yaml)
 
-    yield temp_file.name
+    yield temp_file
 
-    if os.path.exists(temp_file.name):
-        os.unlink(temp_file.name)
+    if os.path.exists(temp_file):
+        os.unlink(temp_file)
 
 
 @pytest.fixture

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -1,0 +1,114 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+import torch
+
+import caustics
+from utils.models import setup_complex_multiplane_yaml
+
+
+@pytest.fixture
+def sim_yaml():
+    return """\
+    cosmology: &cosmo
+        name: cosmo
+        kind: FlatLambdaCDM
+
+    lens: &lens
+        name: lens
+        kind: SIE
+        init_kwargs:
+            cosmology: *cosmo
+
+    src: &src
+        name: source
+        kind: Sersic
+
+    lnslt: &lnslt
+        name: lenslight
+        kind: Sersic
+
+    simulator:
+        name: minisim
+        kind: Lens_Source
+        init_kwargs:
+            # Single lense
+            lens: *lens
+            source: *src
+            lens_light: *lnslt
+            pixelscale: 0.05
+            pixels_x: 100
+    """
+
+
+@pytest.fixture
+def sim_yaml_file(sim_yaml):
+    with NamedTemporaryFile("w") as f:
+        f.write(sim_yaml)
+        f.flush()
+        yield f.name
+
+
+@pytest.fixture
+def sim_obj():
+    cosmology = caustics.FlatLambdaCDM()
+    sie = caustics.SIE(cosmology=cosmology, name="lens")
+    src = caustics.Sersic(name="source")
+    lnslt = caustics.Sersic(name="lenslight")
+    return caustics.Lens_Source(
+        lens=sie, source=src, lens_light=lnslt, pixelscale=0.05, pixels_x=100
+    )
+
+
+def test_build_simulator(sim_yaml_file, sim_obj):
+    # TODO: Add test for using state_dict
+    sim = caustics.build_simulator(sim_yaml_file)
+    x = torch.tensor([
+    #   z_s  z_l   x0   y0   q    phi     b    x0   y0   q     phi    n    Re
+        1.5, 0.5, -0.2, 0.0, 0.4, 1.5708, 1.7, 0.0, 0.0, 0.5, -0.985, 1.3, 1.0,
+    #   Ie    x0   y0   q    phi  n   Re   Ie
+        5.0, -0.2, 0.0, 0.8, 0.0, 1., 1.0, 10.0
+    ])  # fmt: skip
+
+    result = sim(x, quad_level=3)
+    expected_result = sim_obj(x, quad_level=3)
+    assert sim.get_graph(True, True)
+    assert isinstance(result, torch.Tensor)
+    assert torch.allclose(result, expected_result)
+
+
+def test_complex_build_simulator():
+    yaml_str = setup_complex_multiplane_yaml()
+    x = torch.tensor(
+        [
+            #   z_s   x0   y0   q     phi    n    Re
+            1.5,
+            0.0,
+            0.0,
+            0.5,
+            -0.985,
+            1.3,
+            1.0,
+            #   Ie    x0   y0   q    phi  n   Re   Ie
+            5.0,
+            -0.2,
+            0.0,
+            0.8,
+            0.0,
+            1.0,
+            1.0,
+            10.0,
+        ]
+    )
+    with NamedTemporaryFile("w", delete=True) as f:
+        f.write(yaml_str)
+        f.flush()
+        sim = caustics.build_simulator(f.name)
+        image = sim(x, quad_level=3)
+        assert isinstance(image, torch.Tensor)
+        f.close()
+
+
+def test_build_simulator_w_state():
+    # TODO: Add test for using state_dict
+    pass

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -56,7 +56,7 @@ def _write_temp_yaml(yaml_str: str):
 def sim_yaml_file(sim_yaml):
     temp_file = _write_temp_yaml(sim_yaml)
 
-    yield temp_file
+    yield temp_file.name
 
     if os.path.exists(temp_file.name):
         os.unlink(temp_file.name)
@@ -117,13 +117,13 @@ def test_complex_build_simulator():
     temp_file = _write_temp_yaml(yaml_str)
 
     # Open the temp file and build the simulator
-    sim = caustics.build_simulator(temp_file.name)
+    sim = caustics.build_simulator(temp_file)
     image = sim(x, quad_level=3)
     assert isinstance(image, torch.Tensor)
 
     # Remove the temp file
-    if os.path.exists(temp_file.name):
-        os.unlink(temp_file.name)
+    if os.path.exists(temp_file):
+        os.unlink(temp_file)
 
 
 def test_build_simulator_w_state():

--- a/tests/models/test_mod_api.py
+++ b/tests/models/test_mod_api.py
@@ -1,4 +1,6 @@
 from tempfile import NamedTemporaryFile
+import sys
+import os
 
 import pytest
 import torch
@@ -100,13 +102,16 @@ def test_complex_build_simulator():
             10.0,
         ]
     )
-    with NamedTemporaryFile("w", delete=True) as f:
+    delete_file = False if sys.platform.startswith("win") else True
+    with NamedTemporaryFile("w", delete=delete_file) as f:  # Don't delete for windows
         f.write(yaml_str)
         f.flush()
         sim = caustics.build_simulator(f.name)
         image = sim(x, quad_level=3)
         assert isinstance(image, torch.Tensor)
         f.close()
+        if not delete_file:
+            os.unlink(f.name)
 
 
 def test_build_simulator_w_state():

--- a/tests/models/test_mod_registry.py
+++ b/tests/models/test_mod_registry.py
@@ -1,0 +1,97 @@
+import pytest
+
+import caustics
+from caustics.models.registry import (
+    _KindRegistry,
+    available_kinds,
+    register_kind,
+    get_kind,
+    _registry,
+)
+from caustics.parameter import Parameter
+from caustics.parametrized import Parametrized
+
+
+class TestKindRegistry:
+    expected_attrs = [
+        "cosmology",
+        "single_lenses",
+        "multi_lenses",
+        "light",
+        "simulators",
+        "known_kinds",
+        "_m",
+    ]
+
+    def test_constructor(self):
+        registry = _KindRegistry()
+
+        for attr in self.expected_attrs:
+            assert hasattr(registry, attr)
+
+    @pytest.mark.parametrize("kind", ["NonExistingClass", "SIE", caustics.Sersic])
+    def test_getitem(self, kind, mocker):
+        registry = _KindRegistry()
+
+        if kind == "NonExistingClass":
+            with pytest.raises(KeyError):
+                registry[kind]
+        elif isinstance(kind, str):
+            cls = registry[kind]
+            assert cls == getattr(caustics, kind)
+        else:
+            test_key = "TestSersic"
+            registry.known_kinds[test_key] = kind
+            cls = registry[test_key]
+            assert cls == kind
+
+    @pytest.mark.parametrize("kind", [Parameter, caustics.Sersic, "caustics.SIE"])
+    def test_setitem(self, kind):
+        registry = _KindRegistry()
+        key = "TestSersic"
+        if isinstance(kind, str):
+            registry[key] = kind
+            assert key in registry._m
+        elif issubclass(kind, Parametrized):
+            registry[key] = kind
+            assert registry[key] == kind
+        else:
+            with pytest.raises(ValueError):
+                registry[key] = kind
+
+    def test_delitem(self):
+        registry = _KindRegistry()
+        with pytest.raises(NotImplementedError):
+            del registry["Sersic"]
+
+    def test_len(self):
+        registry = _KindRegistry()
+        assert len(registry) == len(set(registry._m))
+
+    def test_iter(self):
+        registry = _KindRegistry()
+        assert set(registry) == set(registry._m)
+
+
+def test_available_kinds():
+    assert available_kinds() == list(_registry)
+
+
+def test_register_kind():
+    key = "TestSersic2"
+    value = caustics.Sersic
+    register_kind(key, value)
+    assert key in _registry._m
+    assert _registry[key] == value
+
+    with pytest.raises(ValueError):
+        register_kind("SIE", "caustics.SIE")
+
+
+def test_get_kind():
+    kind = "Sersic"
+    cls = get_kind(kind)
+    assert cls == caustics.Sersic
+    kind = "NonExistingClass"
+    with pytest.raises(KeyError):
+        cls = get_kind(kind)

--- a/tests/models/test_mod_utils.py
+++ b/tests/models/test_mod_utils.py
@@ -1,0 +1,118 @@
+import pytest
+import inspect
+import typing
+from typing import Annotated, Dict
+from caustics.models.registry import _registry, get_kind
+from caustics.models.utils import (
+    create_pydantic_model,
+    setup_pydantic_models,
+    setup_simulator_models,
+    _get_kwargs_field_definitions,
+    PARAMS,
+    INIT_KWARGS,
+)
+from caustics.models.base_models import Base
+from caustics.parametrized import ClassParam
+
+
+@pytest.fixture(params=_registry.known_kinds)
+def kind(request):
+    return request.param
+
+
+@pytest.fixture
+def parametrized_class(kind):
+    return get_kind(kind)
+
+
+def test_create_pydantic_model(kind):
+    model = create_pydantic_model(kind)
+    kind_cls = get_kind(kind)
+    expected_fields = {"kind", "name", "params", "init_kwargs"}
+
+    assert model.__base__ == Base
+    assert model.__name__ == kind
+    assert model._cls == kind_cls
+    assert set(model.model_fields.keys()) == expected_fields
+
+
+def test__get_kwargs_field_definitions(parametrized_class):
+    kwargs_fd = _get_kwargs_field_definitions(parametrized_class)
+
+    cls_signature = inspect.signature(parametrized_class)
+    class_metadata = {
+        k: {
+            "dtype": v.annotation.__origin__,
+            "default": v.default,
+            "class_param": ClassParam(*v.annotation.__metadata__),
+        }
+        for k, v in cls_signature.parameters.items()
+    }
+
+    for k, v in class_metadata.items():
+        if k != "name":
+            if v["class_param"].isParam:
+                assert k in kwargs_fd[PARAMS]
+                assert isinstance(kwargs_fd[PARAMS][k], tuple)
+                assert kwargs_fd[PARAMS][k][0] == v["dtype"]
+                field_info = kwargs_fd[PARAMS][k][1]
+            else:
+                assert k in kwargs_fd[INIT_KWARGS]
+                assert isinstance(kwargs_fd[INIT_KWARGS][k], tuple)
+                assert kwargs_fd[INIT_KWARGS][k][0] == v["dtype"]
+                field_info = kwargs_fd[INIT_KWARGS][k][1]
+
+            if v["default"] == inspect._empty:
+                # Skip empty defaults
+                continue
+            assert field_info.default == v["default"]
+
+
+def _check_nested_discriminated_union(
+    input_anno: type[Annotated], class_paths: Dict[str, str]
+):
+    # Check to see if the model selection is Annotated type
+    assert typing.get_origin(input_anno) == Annotated
+    # Check to see if the discriminator is "kind"
+    assert input_anno.__metadata__[0].discriminator == "kind"
+
+    if typing.get_origin(input_anno.__origin__) == typing.Union:
+        models = input_anno.__origin__.__args__
+    else:
+        # For single models
+        models = [input_anno.__origin__]
+
+    # Check to see if the models are in the registry
+    assert len(models) == len(class_paths)
+    # Go through each model and check that it's pointing to the right class
+    for model in models:
+        assert model.__name__ in class_paths
+        assert model._cls == get_kind(model.__name__)
+
+
+def test_setup_pydantic_models():
+    # light, lenses
+    pydantic_models_annotated = setup_pydantic_models()
+
+    registry_dict = {
+        "light": _registry.light,
+        "lenses": {
+            **_registry.single_lenses,
+            **_registry.multi_lenses,
+        },
+    }
+
+    pm_anno_dict = {
+        k: v for (k, v) in zip(list(registry_dict.keys()), pydantic_models_annotated)
+    }
+
+    for key, pydantic_model_anno in pm_anno_dict.items():
+        class_paths = registry_dict[key]
+        _check_nested_discriminated_union(pydantic_model_anno, class_paths)
+
+
+def test_setup_simulator_models():
+    simulators = setup_simulator_models()
+
+    class_paths = _registry.simulators
+    _check_nested_discriminated_union(simulators, class_paths)

--- a/tests/test_epl.py
+++ b/tests/test_epl.py
@@ -1,4 +1,5 @@
 from math import pi
+import yaml
 
 import lenstronomy.Util.param_util as param_util
 import torch
@@ -9,10 +10,25 @@ from caustics.cosmology import FlatLambdaCDM
 from caustics.lenses import EPL
 
 
-def test_lenstronomy(device):
-    # Models
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lens = EPL(name="epl", cosmology=cosmology)
+def test_lenstronomy(sim_source, device, lens_models):
+    if sim_source == "yaml":
+        yaml_str = """\
+        cosmology: &cosmology
+            name: cosmo
+            kind: FlatLambdaCDM
+        lens: &lens
+            name: epl
+            kind: EPL
+            init_kwargs:
+                cosmology: *cosmology
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = lens_models.get("EPL")
+        lens = mod(**yaml_dict["lens"]).model_obj()
+    else:
+        # Models
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lens = EPL(name="epl", cosmology=cosmology)
     lens = lens.to(device=device)
     # There is also an EPL_NUMBA class lenstronomy, but it shouldn't matter much
     lens_model_list = ["EPL"]

--- a/tests/test_external_shear.py
+++ b/tests/test_external_shear.py
@@ -1,4 +1,5 @@
 import torch
+import yaml
 from lenstronomy.LensModel.lens_model import LensModel
 from utils import lens_test_helper
 
@@ -6,13 +7,28 @@ from caustics.cosmology import FlatLambdaCDM
 from caustics.lenses import ExternalShear
 
 
-def test(device):
+def test(sim_source, device, lens_models):
     atol = 1e-5
     rtol = 1e-5
 
-    # Models
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lens = ExternalShear(name="shear", cosmology=cosmology)
+    if sim_source == "yaml":
+        yaml_str = """\
+        cosmology: &cosmology
+            name: cosmo
+            kind: FlatLambdaCDM
+        lens: &lens
+            name: shear
+            kind: ExternalShear
+            init_kwargs:
+                cosmology: *cosmology
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = lens_models.get("ExternalShear")
+        lens = mod(**yaml_dict["lens"]).model_obj()
+    else:
+        # Models
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lens = ExternalShear(name="shear", cosmology=cosmology)
     lens.to(device=device)
     lens_model_list = ["SHEAR"]
     lens_ls = LensModel(lens_model_list=lens_model_list)

--- a/tests/test_masssheet.py
+++ b/tests/test_masssheet.py
@@ -1,14 +1,30 @@
 import torch
+import yaml
 
 from caustics.cosmology import FlatLambdaCDM
 from caustics.lenses import MassSheet
 from caustics.utils import get_meshgrid
 
 
-def test(device):
-    # Models
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lens = MassSheet(name="sheet", cosmology=cosmology)
+def test(sim_source, device, lens_models):
+    if sim_source == "yaml":
+        yaml_str = """\
+        cosmology: &cosmology
+            name: cosmo
+            kind: FlatLambdaCDM
+        lens: &lens
+            name: sheet
+            kind: MassSheet
+            init_kwargs:
+                cosmology: *cosmology
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = lens_models.get("MassSheet")
+        lens = mod(**yaml_dict["lens"]).model_obj()
+    else:
+        # Models
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lens = MassSheet(name="sheet", cosmology=cosmology)
 
     lens.to(device=device)
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,4 +1,5 @@
 import torch
+import yaml
 from lenstronomy.LensModel.lens_model import LensModel
 from utils import lens_test_helper
 
@@ -6,13 +7,31 @@ from caustics.cosmology import FlatLambdaCDM
 from caustics.lenses import Point
 
 
-def test(device):
+def test(sim_source, device, lens_models):
     atol = 1e-5
     rtol = 1e-5
+    z_l = torch.tensor(0.9)
 
-    # Models
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lens = Point(name="point", cosmology=cosmology, z_l=torch.tensor(0.9))
+    if sim_source == "yaml":
+        yaml_str = f"""\
+        cosmology: &cosmology
+            name: cosmo
+            kind: FlatLambdaCDM
+        lens: &lens
+            name: point
+            kind: Point
+            params:
+                z_l: {float(z_l)}
+            init_kwargs:
+                cosmology: *cosmology
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = lens_models.get("Point")
+        lens = mod(**yaml_dict["lens"]).model_obj()
+    else:
+        # Models
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lens = Point(name="point", cosmology=cosmology, z_l=z_l)
     lens_model_list = ["POINT_MASS"]
     lens_ls = LensModel(lens_model_list=lens_model_list)
 

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -1,5 +1,6 @@
 import lenstronomy.Util.param_util as param_util
 import numpy as np
+import yaml
 import torch
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.LightModel.light_model import LightModel
@@ -8,13 +9,26 @@ from caustics.light import Sersic
 from caustics.utils import get_meshgrid
 
 
-def test(device):
+def test(sim_source, device, light_models):
     # Caustics setup
     res = 0.05
     nx = 200
     ny = 200
     thx, thy = get_meshgrid(res, nx, ny, device=device)
-    sersic = Sersic(name="sersic", use_lenstronomy_k=True)
+
+    if sim_source == "yaml":
+        yaml_str = """\
+        light:
+            name: sersic
+            kind: Sersic
+            init_kwargs:
+                use_lenstronomy_k: true
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = light_models.get("Sersic")
+        sersic = mod(**yaml_dict["light"]).model_obj()
+    else:
+        sersic = Sersic(name="sersic", use_lenstronomy_k=True)
     sersic.to(device=device)
     # Lenstronomy setup
     ra_at_xy_0, dec_at_xy_0 = (-5 + res / 2, -5 + res / 2)

--- a/tests/test_sie.py
+++ b/tests/test_sie.py
@@ -1,4 +1,5 @@
 from math import pi
+import yaml
 
 import lenstronomy.Util.param_util as param_util
 import torch
@@ -10,13 +11,28 @@ from caustics.lenses import SIE
 from caustics.utils import get_meshgrid
 
 
-def test(device):
+def test(sim_source, device, lens_models):
     atol = 1e-5
     rtol = 1e-5
 
-    # Models
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lens = SIE(name="sie", cosmology=cosmology)
+    if sim_source == "yaml":
+        yaml_str = """\
+        cosmology: &cosmology
+            name: cosmo
+            kind: FlatLambdaCDM
+        lens: &lens
+            name: sie
+            kind: SIE
+            init_kwargs:
+                cosmology: *cosmology
+        """
+        yaml_dict = yaml.safe_load(yaml_str.encode("utf-8"))
+        mod = lens_models.get("SIE")
+        lens = mod(**yaml_dict["lens"]).model_obj()
+    else:
+        # Models
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lens = SIE(name="sie", cosmology=cosmology)
     lens_model_list = ["SIE"]
     lens_ls = LensModel(lens_model_list=lens_model_list)
 

--- a/tests/test_simulator_runs.py
+++ b/tests/test_simulator_runs.py
@@ -7,40 +7,114 @@ from caustics.cosmology import FlatLambdaCDM
 from caustics.lenses import SIE
 from caustics.light import Sersic
 from caustics.utils import gaussian
+from caustics import build_simulator
+
+from utils import mock_from_file
 
 
-def test_simulator_runs(device):
-    # Model
-    cosmology = FlatLambdaCDM(name="cosmo")
-    lensmass = SIE(
-        name="lens",
-        cosmology=cosmology,
-        z_l=1.0,
-        x0=0.0,
-        y0=0.01,
-        q=0.5,
-        phi=pi / 3.0,
-        b=1.0,
-    )
+def test_simulator_runs(sim_source, device, mocker):
+    if sim_source == "yaml":
+        yaml_str = """\
+        cosmology: &cosmology
+            name: "cosmo"
+            kind: FlatLambdaCDM
 
-    source = Sersic(
-        name="source", x0=0.01, y0=-0.03, q=0.6, phi=-pi / 4, n=2.0, Re=0.5, Ie=1.0
-    )
-    lenslight = Sersic(
-        name="lenslight", x0=0.0, y0=0.01, q=0.7, phi=pi / 4, n=3.0, Re=0.7, Ie=1.0
-    )
+        lensmass: &lensmass
+            name: lens
+            kind: SIE
+            params:
+                z_l: 1.0
+                x0: 0.0
+                y0: 0.01
+                q: 0.5
+                phi: pi / 3.0
+                b: 1.0
+            init_kwargs:
+                cosmology: *cosmology
 
-    psf = gaussian(0.05, 11, 11, 0.2, upsample=2)
+        source: &source
+            name: source
+            kind: Sersic
+            params:
+                x0: 0.01
+                y0: -0.03
+                q: 0.6
+                phi: -pi / 4
+                n: 2.0
+                Re: 0.5
+                Ie: 1.0
 
-    sim = Lens_Source(
-        lens=lensmass,
-        source=source,
-        pixelscale=0.05,
-        pixels_x=50,
-        lens_light=lenslight,
-        psf=psf,
-        z_s=2.0,
-    )
+        lenslight: &lenslight
+            name: lenslight
+            kind: Sersic
+            params:
+                x0: 0.0
+                y0: 0.01
+                q: 0.7
+                phi: pi / 4
+                n: 3.0
+                Re: 0.7
+                Ie: 1.0
+
+        psf: &psf
+            func: caustics.utils.gaussian
+            kwargs:
+                pixelscale: 0.05
+                nx: 11
+                ny: 12
+                sigma: 0.2
+                upsample: 2
+
+        simulator:
+            name: simulator
+            kind: Lens_Source
+            params:
+                z_s: 2.0
+            init_kwargs:
+                # Single lense
+                lens: *lensmass
+                source: *source
+                lens_light: *lenslight
+                pixelscale: 0.05
+                pixels_x: 50
+                psf: *psf
+        """
+        mock_from_file(mocker, yaml_str)
+        sim = build_simulator("/path/to/sim.yaml")  # Path doesn't actually exists
+    else:
+        # Model
+        cosmology = FlatLambdaCDM(name="cosmo")
+        lensmass = SIE(
+            name="lens",
+            cosmology=cosmology,
+            z_l=1.0,
+            x0=0.0,
+            y0=0.01,
+            q=0.5,
+            phi=pi / 3.0,
+            b=1.0,
+        )
+
+        source = Sersic(
+            name="source", x0=0.01, y0=-0.03, q=0.6, phi=-pi / 4, n=2.0, Re=0.5, Ie=1.0
+        )
+        lenslight = Sersic(
+            name="lenslight", x0=0.0, y0=0.01, q=0.7, phi=pi / 4, n=3.0, Re=0.7, Ie=1.0
+        )
+
+        psf = gaussian(0.05, 11, 11, 0.2, upsample=2)
+
+        sim = Lens_Source(
+            name="simulator",
+            lens=lensmass,
+            source=source,
+            pixelscale=0.05,
+            pixels_x=50,
+            lens_light=lenslight,
+            psf=psf,
+            z_s=2.0,
+        )
+
     sim.to(device=device)
 
     assert torch.all(torch.isfinite(sim()))

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -15,6 +15,14 @@ from caustics.utils import get_meshgrid
 from caustics.sims import Simulator
 from caustics.cosmology import FlatLambdaCDM
 
+def mock_from_file(mocker, yaml_str):
+    # Mock the from_file function
+    # this way, we don't need to use a real file
+    mocker.patch(
+        'caustics.models.api.from_file',
+        return_value=yaml_str.encode('utf-8')
+    )
+
 
 def setup_simulator(cosmo_static=False, use_nfw=True, simulator_static=False, batched_params=False, device=None):
     n_pix = 20

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -14,15 +14,11 @@ from caustics.light import Sersic, Pixelated
 from caustics.utils import get_meshgrid
 from caustics.sims import Simulator
 from caustics.cosmology import FlatLambdaCDM
+from .models import mock_from_file
 
-def mock_from_file(mocker, yaml_str):
-    # Mock the from_file function
-    # this way, we don't need to use a real file
-    mocker.patch(
-        'caustics.models.api.from_file',
-        return_value=yaml_str.encode('utf-8')
-    )
-
+__all__ = (
+    "mock_from_file",
+)
 
 def setup_simulator(cosmo_static=False, use_nfw=True, simulator_static=False, batched_params=False, device=None):
     n_pix = 20

--- a/tests/utils/models.py
+++ b/tests/utils/models.py
@@ -1,0 +1,178 @@
+import yaml
+import torch
+import numpy as np
+
+import caustics
+
+
+def mock_from_file(mocker, yaml_str):
+    # Mock the from_file function
+    # this way, we don't need to use a real file
+    mocker.patch("caustics.models.api.from_file", return_value=yaml_str.encode("utf-8"))
+
+
+def obj_to_yaml(obj_dict: dict):
+    yaml_string = yaml.safe_dump(obj_dict, sort_keys=False)
+    string_list = yaml_string.split("\n")
+    id_str = string_list[0] + f" &{string_list[0]}".strip(":")
+    string_list[0] = id_str
+    return "\n".join(string_list).replace("'", "")
+
+
+def setup_complex_multiplane_yaml():
+    # initialization stuff for lenses
+    cosmology = caustics.FlatLambdaCDM(name="cosmo")
+    cosmo = {
+        cosmology.name: {
+            "name": cosmology.name,
+            "kind": cosmology.__class__.__name__,
+        }
+    }
+    cosmology.to(dtype=torch.float32)
+    n_pix = 100
+    res = 0.05
+    upsample_factor = 2
+    fov = res * n_pix
+    thx, thy = caustics.utils.get_meshgrid(
+        res / upsample_factor,
+        upsample_factor * n_pix,
+        upsample_factor * n_pix,
+        dtype=torch.float32,
+    )
+    z_s = torch.tensor(1.5, dtype=torch.float32)
+    all_lenses = []
+    all_single_planes = []
+
+    N_planes = 10
+    N_lenses = 2  # per plane
+
+    z_plane = np.linspace(0.1, 1.0, N_planes)
+    planes = []
+
+    for p, z_p in enumerate(z_plane):
+        lenses = []
+        lens_keys = []
+
+        if p == N_planes // 2:
+            lens = caustics.NFW(
+                cosmology=cosmology,
+                z_l=z_p,
+                x0=torch.tensor(0.0),
+                y0=torch.tensor(0.0),
+                m=torch.tensor(10**11),
+                c=torch.tensor(10.0),
+                s=torch.tensor(0.001),
+            )
+            lenses.append(lens)
+            all_lenses.append(
+                {
+                    lens.name: {
+                        "name": lens.name,
+                        "kind": lens.__class__.__name__,
+                        "params": {
+                            k: float(v.value)
+                            for k, v in lens.module_params.static.items()
+                        },
+                        "init_kwargs": {"cosmology": f"*{cosmology.name}"},
+                    }
+                }
+            )
+            lens_keys.append(f"*{lens.name}")
+        else:
+            for _ in range(N_lenses):
+                lens = caustics.NFW(
+                    cosmology=cosmology,
+                    z_l=z_p,
+                    x0=torch.tensor(np.random.uniform(-fov / 2.0, fov / 2.0)),
+                    y0=torch.tensor(np.random.uniform(-fov / 2.0, fov / 2.0)),
+                    m=torch.tensor(10 ** np.random.uniform(8, 9)),
+                    c=torch.tensor(np.random.uniform(4, 40)),
+                    s=torch.tensor(0.001),
+                )
+                lenses.append(lens)
+                all_lenses.append(
+                    {
+                        lens.name: {
+                            "name": lens.name,
+                            "kind": lens.__class__.__name__,
+                            "params": {
+                                k: float(v.value)
+                                for k, v in lens.module_params.static.items()
+                            },
+                            "init_kwargs": {"cosmology": f"*{cosmology.name}"},
+                        }
+                    }
+                )
+                lens_keys.append(f"*{lens.name}")
+
+        single_plane = caustics.lenses.SinglePlane(
+            z_l=z_p, cosmology=cosmology, lenses=lenses, name=f"plane_{p}"
+        )
+        planes.append(single_plane)
+        all_single_planes.append(
+            {
+                single_plane.name: {
+                    "name": single_plane.name,
+                    "kind": single_plane.__class__.__name__,
+                    "params": {
+                        k: float(v.value)
+                        for k, v in single_plane.module_params.static.items()
+                    },
+                    "init_kwargs": {
+                        "lenses": lens_keys,
+                        "cosmology": f"*{cosmology.name}",
+                    },
+                }
+            }
+        )
+
+    lens = caustics.lenses.Multiplane(
+        name="multiplane", cosmology=cosmology, lenses=planes
+    )
+    multi_dict = {
+        lens.name: {
+            "name": lens.name,
+            "kind": lens.__class__.__name__,
+            "init_kwargs": {
+                "lenses": [f"*{p.name}" for p in planes],
+                "cosmology": f"*{cosmology.name}",
+            },
+        }
+    }
+    lenses_yaml = (
+        [obj_to_yaml(cosmo)]
+        + [obj_to_yaml(lens) for lens in all_lenses]
+        + [obj_to_yaml(plane) for plane in all_single_planes]
+        + [obj_to_yaml(multi_dict)]
+    )
+    
+    source_yaml = obj_to_yaml({
+        "source": {
+            "name": "source",
+            "kind": "Sersic",
+        }
+    })
+    
+    lenslight_yaml = obj_to_yaml({
+        "lnslight": {
+            "name": "lnslight",
+            "kind": "Sersic",
+        }
+    })
+    
+    sim_yaml = obj_to_yaml({
+        "simulator": {
+            "name": "sim",
+            "kind": "Lens_Source",
+            "init_kwargs": {
+                "lens": f"*{lens.name}",
+                "source": "*source",
+                "lens_light": "*lnslight",
+                "pixelscale": 0.05,
+                "pixels_x": 100,
+            }
+        }
+    })
+    
+    all_yaml_list = lenses_yaml + [source_yaml, lenslight_yaml, sim_yaml]
+    return "\n".join(all_yaml_list)


### PR DESCRIPTION
## Overview

This PR introduces a function called `build_simulator` which can take a YAML configuration file to build simulator from that file. An example YAML configuration can be:

```yaml
cosmology: &cosmo
    name: cosmo
    kind: FlatLambdaCDM
    
lens: &lens
    name: lens
    kind: SIE
    params:
        z_l: 1.0
        x0: 0.0
        y0: 0.01
        q: 0.5
        phi: pi / 3.0
        b: 1.0
    init_kwargs:
        cosmology: *cosmo
        
source: &source
    name: source
    kind: Sersic
    params:
        x0: 0.01
        y0: -0.03
        q: 0.6
        phi: -pi / 4
        n: 2.0
        Re: 0.5
        Ie: 1.0

lnslt: &lnslt
    name: lenslight
    kind: Sersic
    params:
        x0: 0.0
        y0: 0.01
        q: 0.7
        phi: pi / 4
        n: 3.0
        Re: 0.7
        Ie: 1.0
    
simulator:
    name: minisim
    kind: Lens_Source
    params:
        z_s: 2.0
    init_kwargs:
        # Single lense
        lens: *lens
        source: *source
        lens_light: *lnslt
        pixelscale: 0.05
        pixels_x: 50
        psf:
            # Special kind of input
            # this will not get validated other than
            # the fact that it is a dictionary 
            # with "func" and "kwargs" keys
            func: caustics.utils.gaussian
            kwargs:
                pixelscale: 0.05
                nx: 11
                ny: 12
                sigma: 0.2
                upsample: 2
```

With the above yaml file a user can create a simulator called "minisim" with `caustics.build_simulator`. This functionality leverages [pydantic v2](https://docs.pydantic.dev/latest/) and typing quite heavily to give a lot more metadata regarding the arguments that are inputs for each of the Parametrized sub-class.