### PR TITLE
ci: Fix docker image build issue with it getting to both load and push

### DIFF
--- a/.github/workflows/image_ci.yml
+++ b/.github/workflows/image_ci.yml
@@ -102,11 +102,8 @@ jobs:
           context: .
           file: ./resources/docker/Dockerfile
           platforms: linux/amd64
-          load: ${{ env.GITHUB_REF != 'refs/heads/main' || env.GITHUB_REF !=
-            'refs/heads/dev' }}
-          push:
-            ${{ env.GITHUB_REF == 'refs/heads/main' || env.GITHUB_REF ==
-            'refs/heads/dev' }}
+          load: ${{ !contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'), env.GITHUB_REF) }}
+          push: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'), env.GITHUB_REF) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/image_ci.yml
+++ b/.github/workflows/image_ci.yml
@@ -102,8 +102,12 @@ jobs:
           context: .
           file: ./resources/docker/Dockerfile
           platforms: linux/amd64
-          load: ${{ !contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'), env.GITHUB_REF) }}
-          push: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'), env.GITHUB_REF) }}
+          load:
+            ${{ !contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'),
+            env.GITHUB_REF) }}
+          push:
+            ${{ contains(fromJSON('["refs/heads/main", "refs/heads/dev"]'),
+            env.GITHUB_REF) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/image_ci.yml
+++ b/.github/workflows/image_ci.yml
@@ -12,6 +12,7 @@ on:
       - "resources/docker/*.lock"
       - "resources/docker/*.yaml"
       - "resources/docker/*.sh"
+      - ".github/workflows/image_ci.yml"
   pull_request:
     branches:
       - "dev-**"

--- a/.github/workflows/image_ci.yml
+++ b/.github/workflows/image_ci.yml
@@ -102,7 +102,8 @@ jobs:
           context: .
           file: ./resources/docker/Dockerfile
           platforms: linux/amd64
-          load: ${{ env.GITHUB_REF != 'refs/heads/main' }}
+          load: ${{ env.GITHUB_REF != 'refs/heads/main' || env.GITHUB_REF !=
+            'refs/heads/dev' }}
           push:
             ${{ env.GITHUB_REF == 'refs/heads/main' || env.GITHUB_REF ==
             'refs/heads/dev' }}


### PR DESCRIPTION
## Overview

This PR adds a patch fix to the docker image build ending up having both `load` and `push` which is invalid for that action.