### PR TITLE
Fixing multiplane

### DIFF
--- a/src/caustics/constants.py
+++ b/src/caustics/constants.py
@@ -22,4 +22,5 @@ G_over_c2 = float((_G_astropy / _c_astropy**2).to("Mpc/solMass").value)  # type:
 c_Mpc_s = float(_c_astropy.to("Mpc/s").value)
 km_to_Mpc = 3.2407792896664e-20  # TODO: use astropy
 days_to_seconds = 24.0 * 60.0 * 60.0
+seconds_to_days = 1/days_to_seconds
 # fmt: on

--- a/src/caustics/lenses/sie.py
+++ b/src/caustics/lenses/sie.py
@@ -131,7 +131,7 @@ class SIE(ThinLens):
         Tensor
             The radial coordinate in the lens plane.
 
-            *Unit: arcsec*
+            *Unit: arcsec^2*
 
         """
         return (q**2 * (x**2 + self.s**2) + y**2).sqrt()  # fmt: skip


### PR DESCRIPTION
coauthor: @andreasfilipp 

We are fixing the math of the multiplane class based on Fleury et al. (2022). Doing this, we realize that lenstronomy must be wrong. The multiplane equation is actually much simpler than we thought. It's just recursively applying the single thin lens equation, while updating the coordinate. 

All the normalization quantities, like $\Sigma_{\mathrm{crit}}$, are computed by taking the **next** plane as the source plane. This is how the math stays internally consistent. 

Also fixed the Shapiro time delay units, from days * arcsec^2 to days. A conversion factor was missing.

This PR also attempts to fix the circular logic in the `ThinPlane` class by forcing inherited class to implement the `reduced_deflection_angle` method. The `physical_deflection_angle` method is then just a wrapper on the previous one. See Issue #242. 


