### PR TITLE
feat: adding scale parameters to pixelated models

### DIFF
--- a/src/caustics/lenses/pixelated_convergence.py
+++ b/src/caustics/lenses/pixelated_convergence.py
@@ -41,6 +41,9 @@ class PixelatedConvergence(ThinLens):
             "A 2D tensor representing the convergence map",
             True,
         ] = None,
+        scale: Annotated[
+            Optional[Tensor], "A scale factor to multiply by the convergence map", True
+        ] = 1.0,
         shape: Annotated[
             Optional[tuple[int, ...]], "The shape of the convergence map"
         ] = None,
@@ -151,6 +154,7 @@ class PixelatedConvergence(ThinLens):
         self.convergence_map = Param(
             "convergence_map", convergence_map, shape, units="unitless"
         )
+        self.scale = Param("scale", scale, units="flux", valid=(0, None))
 
         if convergence_map is not None:
             self.n_pix = convergence_map.shape[0]
@@ -260,6 +264,7 @@ class PixelatedConvergence(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         convergence_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> tuple[Tensor, Tensor]:
         """
         Compute the deflection angles at the specified positions using the given convergence map.
@@ -292,7 +297,7 @@ class PixelatedConvergence(ThinLens):
         return func.reduced_deflection_angle_pixelated_convergence(
             x0,
             y0,
-            convergence_map,
+            convergence_map * scale,
             x,
             y,
             self.ax_kernel_tilde,
@@ -312,6 +317,7 @@ class PixelatedConvergence(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         convergence_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> Tensor:
         """
         Compute the lensing potential at the specified positions using the given convergence map.
@@ -340,7 +346,7 @@ class PixelatedConvergence(ThinLens):
         return func.potential_pixelated_convergence(
             x0,
             y0,
-            convergence_map,
+            convergence_map * scale,
             x,
             y,
             self.potential_kernel_tilde,
@@ -359,6 +365,7 @@ class PixelatedConvergence(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         convergence_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> Tensor:
         """
         Compute the convergence at the specified positions. This method is not implemented.
@@ -384,7 +391,7 @@ class PixelatedConvergence(ThinLens):
 
         """
         return interp2d(
-            convergence_map,
+            convergence_map * scale,
             (x - x0).view(-1) / self.fov * 2,
             (y - y0).view(-1) / self.fov * 2,
         ).reshape(x.shape)

--- a/src/caustics/lenses/pixelated_potential.py
+++ b/src/caustics/lenses/pixelated_potential.py
@@ -40,6 +40,9 @@ class PixelatedPotential(ThinLens):
             "A 2D tensor representing the potential map",
             True,
         ] = None,
+        scale: Annotated[
+            Optional[Tensor], "A scale factor to multiply by the potential map", True
+        ] = 1.0,
         shape: Annotated[
             Optional[tuple[int, ...]], "The shape of the potential map"
         ] = None,
@@ -106,6 +109,7 @@ class PixelatedPotential(ThinLens):
         self.potential_map = Param(
             "potential_map", potential_map, shape, units="unitless"
         )
+        self.scale = Param("scale", scale, units="flux", valid=(0, None))
 
         self.pixelscale = pixelscale
         if potential_map is not None:
@@ -124,6 +128,7 @@ class PixelatedPotential(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         potential_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> tuple[Tensor, Tensor]:
         """
         Compute the deflection angles at the specified positions using the given convergence map.
@@ -159,7 +164,7 @@ class PixelatedPotential(ThinLens):
             for alpha in interp_bicubic(
                 (x - x0).view(-1) / self.fov * 2,
                 (y - y0).view(-1) / self.fov * 2,
-                potential_map,
+                potential_map * scale,
                 get_Y=False,
                 get_dY=True,
                 get_ddY=False,
@@ -174,6 +179,7 @@ class PixelatedPotential(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         potential_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> Tensor:
         """
         Compute the lensing potential at the specified positions using the given convergence map.
@@ -201,7 +207,7 @@ class PixelatedPotential(ThinLens):
         return interp_bicubic(
             (x - x0).view(-1) / self.fov * 2,
             (y - y0).view(-1) / self.fov * 2,
-            potential_map,
+            potential_map * scale,
             get_Y=True,
             get_dY=False,
             get_ddY=False,
@@ -215,6 +221,7 @@ class PixelatedPotential(ThinLens):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         potential_map: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ) -> Tensor:
         """
         Compute the convergence at the specified positions. This method is not implemented.
@@ -243,7 +250,7 @@ class PixelatedPotential(ThinLens):
         _, dY11, dY22 = interp_bicubic(
             (x - x0).view(-1) / self.fov * 2,
             (y - y0).view(-1) / self.fov * 2,
-            potential_map,
+            potential_map * scale,
             get_Y=False,
             get_dY=False,
             get_ddY=True,

--- a/src/caustics/light/pixelated.py
+++ b/src/caustics/light/pixelated.py
@@ -54,6 +54,7 @@ class Pixelated(Source):
             Optional[Tensor],
             "The source image from which brightness values will be interpolated.",
             True,
+            "flux",
         ] = None,
         x0: Annotated[
             Optional[Union[Tensor, float]],
@@ -71,6 +72,12 @@ class Pixelated(Source):
             True,
             "arcsec/pixel",
         ] = None,
+        scale: Annotated[
+            Optional[Union[Tensor, float]],
+            "A scale factor to multiply by the image",
+            True,
+            "flux",
+        ] = 1.0,
         shape: Annotated[
             Optional[tuple[int, ...]], "The shape of the source image."
         ] = None,
@@ -121,6 +128,7 @@ class Pixelated(Source):
         self.pixelscale = Param(
             "pixelscale", pixelscale, units="arcsec/pixel", valid=(0, None)
         )
+        self.scale = Param("scale", scale, units="flux", valid=(0, None))
 
     @forward
     def brightness(
@@ -131,6 +139,7 @@ class Pixelated(Source):
         y0: Annotated[Tensor, "Param"],
         image: Annotated[Tensor, "Param"],
         pixelscale: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
         padding_mode: str = "zeros",
     ):
         """
@@ -165,7 +174,7 @@ class Pixelated(Source):
         fov_x = pixelscale * image.shape[1]
         fov_y = pixelscale * image.shape[0]
         return interp2d(
-            image,
+            image * scale,
             (x - x0).view(-1) / fov_x * 2,
             (y - y0).view(-1) / fov_y * 2,  # make coordinates bounds at half the fov
             padding_mode=padding_mode,

--- a/src/caustics/light/pixelated_time.py
+++ b/src/caustics/light/pixelated_time.py
@@ -59,6 +59,7 @@ class PixelatedTime(Source):
             Optional[Tensor],
             "The source image cube from which brightness values will be interpolated.",
             True,
+            "flux",
         ] = None,
         x0: Annotated[
             Optional[Union[Tensor, float]],
@@ -82,6 +83,12 @@ class PixelatedTime(Source):
             False,
             "seconds",
         ] = None,
+        scale: Annotated[
+            Optional[Union[Tensor, float]],
+            "A scale factor to multiply by the image",
+            True,
+            "flux",
+        ] = 1.0,
         shape: Annotated[
             Optional[tuple[int, ...]], "The shape of the source image."
         ] = None,
@@ -129,6 +136,7 @@ class PixelatedTime(Source):
         self.x0 = Param("x0", x0, units="arcsec")
         self.y0 = Param("y0", y0, units="arcsec")
         self.cube = Param("cube", cube, shape, units="flux")
+        self.scale = Param("scale", scale, units="flux", valid=(0, None))
         self.pixelscale = pixelscale
         self.t_end = t_end
 
@@ -141,6 +149,7 @@ class PixelatedTime(Source):
         x0: Annotated[Tensor, "Param"],
         y0: Annotated[Tensor, "Param"],
         cube: Annotated[Tensor, "Param"],
+        scale: Annotated[Tensor, "Param"],
     ):
         """
         Implements the `brightness` method for `Pixelated`.
@@ -180,7 +189,7 @@ class PixelatedTime(Source):
         fov_x = self.pixelscale * cube.shape[2]
         fov_y = self.pixelscale * cube.shape[1]
         return interp3d(
-            cube,
+            cube * scale,
             (x - x0).view(-1) / fov_x * 2,
             (y - y0).view(-1) / fov_y * 2,
             (t - self.t_end / 2).view(-1) / self.t_end * 2,

--- a/tests/test_pixelated_time.py
+++ b/tests/test_pixelated_time.py
@@ -1,0 +1,27 @@
+import torch
+import caustics
+
+
+def test_pixelated_time():
+
+    nx, ny = 64, 64
+
+    X, Y = torch.meshgrid(
+        torch.linspace(-5, 5, nx), torch.linspace(-5, 5, ny), indexing="ij"
+    )
+    R = torch.sqrt(X**2 + Y**2)
+    T = torch.linspace(0, 9, 10)
+    cube = torch.stack([torch.exp(-0.5 * R**2 / (0.5 + t)) for t in T])
+
+    cubemodel = caustics.PixelatedTime(
+        cube=cube, x0=0.1, y0=0.2, pixelscale=0.1, t_end=10
+    )
+
+    rescale_pixels = 0.1 * (nx - 1) / 10
+    X = X * rescale_pixels
+    Y = Y * rescale_pixels
+    sample_exact = cubemodel.brightness(X + 0.1, Y + 0.2, torch.ones_like(X) * 4.5)
+    assert torch.allclose(sample_exact, cube[4])
+
+    sample_interp = cubemodel.brightness(X + 0.1, Y + 0.2, torch.ones_like(X) * 5)
+    assert torch.allclose(sample_interp, 0.5 * (cube[4] + cube[5]))


### PR DESCRIPTION
Sometimes it is nice to have the pixelated model fixed and only change the scaling of the model. For example with a PSF image fitting a star. The scale factor could also be used for a diffusion model operating on images with different units, to keep everything in distribution if the main difference is only a global scaling.