### PR TITLE
Warn python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Simply install `caustics` from PyPI:
 pip install caustics
 ```
 
+Note: ``Python 3.9`` through ``3.11`` are recommended; compatibility with versions >=3.12 is currently untested.
+
 ## Minimal Example
 
 ```python

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Simply install `caustics` from PyPI:
 pip install caustics
 ```
 
-Note: `Python 3.9` through `3.11` are recommended; compatibility with
-versions >=3.12 is currently untested.
+Note: `Python 3.9` through `3.12` are recommended; compatibility with
+versions >=3.13 is currently untested.
 
 ## Minimal Example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Simply install `caustics` from PyPI:
 pip install caustics
 ```
 
-Note: ``Python 3.9`` through ``3.11`` are recommended; compatibility with versions >=3.12 is currently untested.
+Note: `Python 3.9` through `3.11` are recommended; compatibility with
+versions >=3.12 is currently untested.
 
 ## Minimal Example
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,7 +5,7 @@ Installation
 Regular Install
 ---------------
 
-The easiest way to install is to make a new ``Python`` virtual environment (``Python 3.9`` through ``3.11`` are recommended; compatibility with versions ``>=3.12`` is currently untested). Then run::
+The easiest way to install is to make a new ``Python`` virtual environment (``Python 3.9`` through ``3.12`` are recommended; compatibility with versions ``>=3.13`` is currently untested). Then run::
 
     pip install caustics
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,7 +5,7 @@ Installation
 Regular Install
 ---------------
 
-The easiest way to install is to make a new virtual environment then run::
+The easiest way to install is to make a new ``Python`` virtual environment (``Python 3.9`` through ``3.11`` are recommended; compatibility with versions ``>=3.12`` is currently untested). Then run::
 
     pip install caustics
 


### PR DESCRIPTION
 Added a warning to the docs and to the ReadME about using Python >=3.12 until we have testing set up for 3.12 (I will then update this warning to >=3.13).