### PR TITLE
Upgrade to compatibility with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.9"
+    rev: "v0.11.10"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Simply install `caustics` from PyPI:
 pip install caustics
 ```
 
+Note: `Python 3.9` through `3.12` are recommended; compatibility with
+versions >=3.13 is currently untested.
+
 ## Minimal Example
 
 ```python

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,7 +5,7 @@ Installation
 Regular Install
 ---------------
 
-The easiest way to install is to make a new virtual environment then run::
+The easiest way to install is to make a new ``Python`` virtual environment (``Python 3.9`` through ``3.12`` are recommended; compatibility with versions ``>=3.13`` is currently untested). Then run::
 
     pip install caustics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Issues = "https://github.com/Ciela-Institute/caustics/issues"
 
 [project.optional-dependencies]
 dev = [
-    "numba>=0.58.1,<0.59.0",
+    "numba>=0.58.1",
     "lenstronomy>1.13.0",
     "pytest>=8.0,<9",
     "pytest-cov>=4.1,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Issues = "https://github.com/Ciela-Institute/caustics/issues"
 [project.optional-dependencies]
 dev = [
     "numba>=0.58.1,<0.59.0",
-    "lenstronomy==1.11.1",
+    "lenstronomy>1.13.0",
     "pytest>=8.0,<9",
     "pytest-cov>=4.1,<5",
     "pytest-mock>=3.12,<4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astropy>=5.2.1,<6.0.0
+astropy>=6.0.0, <7.0.0
 caskade>=0.9.0
 graphviz==0.20.1
 h5py>=3.8.0


### PR DESCRIPTION
Added 3.12 to CI workflow, and I also relaxed the Numba upper version limit. 

More generally, I think that strict version requirements and version upper bounds are generally not best practice for the following reasons:
1. While such reqs aim to improve reproducibility, as a trade-off, they increase the likelihood of conflicts down the road, harming future package maintainers. 
2. Upgrading versions usually fixes bugs rather than introducing new ones. The major exception to this is API changes, but I believe it is the duty of maintainers to adapt to API changes as they occur and set upper version limits as a last resort. 
3. Caustics is less a top-level package, and more of a strong lensing framework which can be built upon by others. Since pinning versions is best done at the top level (see e.g. [the top answer here](https://stackoverflow.com/questions/28509481/should-i-pin-my-python-dependencies-versions)), I believe we should be more cautious about upper bounds, since they are likely to cause cascading version conflicts/increasingly onerous versioning downstream. 

Open to discussing this issue further :) 